### PR TITLE
Allowed Extensions All on ffprobe commands against m3u8 files

### DIFF
--- a/lib/ffmpeg/movie.rb
+++ b/lib/ffmpeg/movie.rb
@@ -19,8 +19,14 @@ module FFMPEG
 
       @path = path
 
+      if @path.end_with?('.m3u8')
+        optional_arguements = ' -allowed_extensions ALL'
+      else
+        optional_arguements = ''
+      end
+
       # ffmpeg will output to stderr
-      command = "#{FFMPEG.ffprobe_binary} -allowed_extensions ALL -i #{Shellwords.escape(path)} -print_format json -show_format -show_streams -show_error"
+      command = "#{FFMPEG.ffprobe_binary}#{optional_arguements} -i #{Shellwords.escape(path)} -print_format json -show_format -show_streams -show_error"
       std_output = ''
       std_error = ''
 

--- a/lib/ffmpeg/movie.rb
+++ b/lib/ffmpeg/movie.rb
@@ -20,7 +20,7 @@ module FFMPEG
       @path = path
 
       # ffmpeg will output to stderr
-      command = "#{FFMPEG.ffprobe_binary} -i #{Shellwords.escape(path)} -print_format json -show_format -show_streams -show_error"
+      command = "#{FFMPEG.ffprobe_binary} -allowed_extensions ALL -i #{Shellwords.escape(path)} -print_format json -show_format -show_streams -show_error"
       std_output = ''
       std_error = ''
 


### PR DESCRIPTION
- This allows newer versions of ffprobe to work on m3u8 manifest's where the encryption key does not have an extension
- ffmpeg commands can have it be set manually as a custom option
- relevant issue - http://ffmpeg.org/pipermail/ffmpeg-cvslog/2017-June/107660.html