### PR TITLE
Use posix-spawn gem instead of Open3

### DIFF
--- a/lib/ffmpeg/movie.rb
+++ b/lib/ffmpeg/movie.rb
@@ -1,5 +1,6 @@
 require 'time'
 require 'multi_json'
+require 'posix-spawn'
 
 module FFMPEG
   class Movie
@@ -27,13 +28,12 @@ module FFMPEG
 
       # ffmpeg will output to stderr
       command = "#{FFMPEG.ffprobe_binary}#{optional_arguements} -i #{Shellwords.escape(path)} -print_format json -show_format -show_streams -show_error"
-      std_output = ''
-      std_error = ''
+      spawn = POSIX::Spawn::Child.new(command)
 
-      Open3.popen3(command) do |stdin, stdout, stderr|
-        std_output = stdout.read unless stdout.nil?
-        std_error = stderr.read unless stderr.nil?
-      end
+      raise "Spawn Error! stdout: #{spawn.out} stderr: #{spawn.err} Command: #{cmd}" unless spawn.success?
+
+      std_output = spawn.out
+      std_error = spawn.err
 
       fix_encoding(std_output)
       fix_encoding(std_error)

--- a/rlovelett-ffmpeg.gemspec
+++ b/rlovelett-ffmpeg.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |s|
   s.summary     = "Wraps ffmpeg to read metadata and transcodes videos."
 
   s.add_dependency('multi_json', '~> 1.8')
+  s.add_dependency('posix-spawn', '~> 0.3.13')
 
   s.add_development_dependency("rspec", "~> 2.14.0")
   s.add_development_dependency("rake", "~> 10.1.0")


### PR DESCRIPTION
ffprobe 4.2.2 causes `Open3.popen3` to hang reading stdin. Using this opportunity to switch to the more efficient methods used in the `posix-spawn` gem (which doesn't hang when reading stdin).

![📵](https://i.imgflip.com/426z9z.jpg)
