### PR TITLE
[Hackaton Prompted] Modern Updates And Extra Options Parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ pkg
 script/*
 tmp/*
 Gemfile.lock
+
+.bundle/*

--- a/lib/ffmpeg/black_detect.rb
+++ b/lib/ffmpeg/black_detect.rb
@@ -54,7 +54,10 @@ module FFMPEG
         end
       end
 
-      @invalid = true if std_error != ''
+      if std_error != ''
+        @invalid = true 
+        FFMPEG.logger.error(std_error)
+      end
 
       raise Error, "Failed to detect black frames: #{std_output} :: #{std_error}" if std_error != ''
 

--- a/lib/ffmpeg/movie.rb
+++ b/lib/ffmpeg/movie.rb
@@ -89,11 +89,13 @@ module FFMPEG
 
           @video_stream = "#{video_stream[:codec_name]} (#{video_stream[:profile]}) (#{video_stream[:codec_tag_string]} / #{video_stream[:codec_tag]}), #{colorspace}, #{resolution} [SAR #{sar} DAR #{dar}]"
 
-          @rotation = if video_stream.key?(:tags) and video_stream[:tags].key?(:rotate)
-                        video_stream[:tags][:rotate].to_i
-                      else
-                        nil
-                      end
+          video_stream[:side_data_list].each do |side_data_entry|
+            @rotation = if side_data_entry.key?(:rotation)
+                          side_data_entry[:rotation].to_i
+                        else
+                          nil
+                        end
+          end if video_stream.key?(:side_data_list)
         end
 
         @audio_streams = audio_streams.map do |stream|

--- a/lib/ffmpeg/movie.rb
+++ b/lib/ffmpeg/movie.rb
@@ -188,12 +188,12 @@ module FFMPEG
       width && height && (width > height)
     end
 
-    def transcode(output_file, options = EncodingOptions.new, transcoder_options = {}, &block)
-      Transcoder.new(self, output_file, options, transcoder_options).run &block
+    def transcode(output_file, options = EncodingOptions.new, transcoder_options = {}, transcoder_prefix_options = {}, &block)
+      Transcoder.new(self, output_file, options, transcoder_options, transcoder_prefix_options).run &block
     end
 
-    def screenshot(output_file, options = EncodingOptions.new, transcoder_options = {}, &block)
-      Transcoder.new(self, output_file, options.merge(screenshot: true), transcoder_options).run &block
+    def screenshot(output_file, options = EncodingOptions.new, transcoder_options = {}, transcoder_prefix_options = {}, &block)
+      Transcoder.new(self, output_file, options.merge(screenshot: true), transcoder_options, transcoder_prefix_options).run &block
     end
 
     def blackdetect

--- a/lib/ffmpeg/transcoder.rb
+++ b/lib/ffmpeg/transcoder.rb
@@ -13,7 +13,7 @@ module FFMPEG
       @@timeout
     end
 
-    def initialize(movie, output_file, options = EncodingOptions.new, transcoder_options = {})
+    def initialize(movie, output_file, options = EncodingOptions.new, transcoder_options = {}, transcoder_prefix_options = {})
       @movie = movie
       @output_file = output_file
 

--- a/lib/ffmpeg/transcoder.rb
+++ b/lib/ffmpeg/transcoder.rb
@@ -18,16 +18,18 @@ module FFMPEG
       @output_file = output_file
 
       if options.is_a?(String)
-        @raw_options = "-i #{Shellwords.escape(@movie.path)} " + options
+        prefix_options = convert_prefix_options_to_string(transcoder_prefix_options)
+        @raw_options = "#{prefix_options}-i #{Shellwords.escape(@movie.path)} #{options}"
       elsif options.is_a?(EncodingOptions)
         @raw_options = options.merge(:input => @movie.path) unless options.include? :input
       elsif options.is_a?(Hash)
-        @raw_options = EncodingOptions.new(options.merge(:input => @movie.path))
+        @raw_options = EncodingOptions.new(options.merge(:input => @movie.path), transcoder_prefix_options)
       else
         raise ArgumentError, "Unknown options format '#{options.class}', should be either EncodingOptions, Hash or String."
       end
 
       @transcoder_options = transcoder_options
+      @transcoder_prefix_options = transcoder_prefix_options
       @errors = []
 
       apply_transcoder_options
@@ -148,6 +150,12 @@ module FFMPEG
       output[/test/]
     rescue ArgumentError
       output.force_encoding("ISO-8859-1")
+    end
+
+    def convert_prefix_options_to_string(transcoder_prefix_options)
+      prefix_options = "#{transcoder_prefix_options.is_a?(String) ? transcoder_prefix_options : EncodingOptions.new(transcoder_prefix_options)}"
+      prefix_options = "#{prefix_options} " if prefix_options.length > 0
+      return prefix_options
     end
   end
 end

--- a/rlovelett-ffmpeg.gemspec
+++ b/rlovelett-ffmpeg.gemspec
@@ -10,8 +10,10 @@ Gem::Specification.new do |s|
   s.authors     = ["David Backeus", "Ryan Lovelett"]
   s.email       = ["david@streamio.com", "ryan@lovelett.me"]
   s.homepage    = "http://github.com/RLovelett/rlovelett-ffmpeg"
+
   s.summary     = "Wraps ffmpeg to read metadata and transcodes videos."
 
+  s.add_dependency "rake", ">= 12.3.3"
   s.add_dependency('multi_json', '~> 1.8')
   s.add_dependency('posix-spawn', '~> 0.3.13')
 

--- a/rlovelett-ffmpeg.gemspec
+++ b/rlovelett-ffmpeg.gemspec
@@ -13,12 +13,11 @@ Gem::Specification.new do |s|
 
   s.summary     = "Wraps ffmpeg to read metadata and transcodes videos."
 
-  s.add_dependency "rake", ">= 12.3.3"
   s.add_dependency('multi_json', '~> 1.8')
   s.add_dependency('posix-spawn', '~> 0.3.13')
 
   s.add_development_dependency("rspec", "~> 2.14.0")
-  s.add_development_dependency("rake", "~> 10.1.0")
+  s.add_development_dependency("rake", ">= 13.0.6")
   s.add_development_dependency("codeclimate-test-reporter", "~> 0.4.7")
 
   s.files        = Dir.glob("lib/**/*") + %w(README.md LICENSE CHANGELOG)

--- a/spec/ffmpeg/encoding_options_spec.rb
+++ b/spec/ffmpeg/encoding_options_spec.rb
@@ -6,25 +6,25 @@ module FFMPEG
 
       it "should order input and seek_time correctly" do
         command = EncodingOptions.new(:input => 'my_movie.mp4', :seek_time => 2500).to_s
-        command.should == '-ss 2500 -i my_movie.mp4'
+        command.should eq('-ss 2500 -i my_movie.mp4')
       end
 
       it "should convert video codec" do
-        EncodingOptions.new(video_codec: "libx264").to_s.should == "-vcodec libx264"
+        EncodingOptions.new(video_codec: "libx264").to_s.should eq("-vcodec libx264")
       end
 
       it "should know the width from the resolution or be nil" do
-        EncodingOptions.new(resolution: "320x240").width.should == 320
+        EncodingOptions.new(resolution: "320x240").width.should eq(320)
         EncodingOptions.new.width.should be_nil
       end
 
       it "should know the height from the resolution or be nil" do
-        EncodingOptions.new(resolution: "320x240").height.should == 240
+        EncodingOptions.new(resolution: "320x240").height.should eq(240)
         EncodingOptions.new.height.should be_nil
       end
 
       it "should convert frame rate" do
-        EncodingOptions.new(frame_rate: 29.9).to_s.should == "-r 29.9"
+        EncodingOptions.new(frame_rate: 29.9).to_s.should eq("-r 29.9")
       end
 
       it "should convert the resolution" do
@@ -43,83 +43,83 @@ module FFMPEG
       end
 
       it "should convert video bitrate" do
-        EncodingOptions.new(video_bitrate: "600k").to_s.should == "-b:v 600k"
+        EncodingOptions.new(video_bitrate: "600k").to_s.should eq("-b:v 600k")
       end
 
       it "should use k unit for video bitrate" do
-        EncodingOptions.new(video_bitrate: 600).to_s.should == "-b:v 600k"
+        EncodingOptions.new(video_bitrate: 600).to_s.should eq("-b:v 600k")
       end
 
       it "should convert audio codec" do
-        EncodingOptions.new(audio_codec: "aac").to_s.should == "-acodec aac"
+        EncodingOptions.new(audio_codec: "aac").to_s.should eq("-acodec aac")
       end
 
       it "should convert audio bitrate" do
-        EncodingOptions.new(audio_bitrate: "128k").to_s.should == "-b:a 128k"
+        EncodingOptions.new(audio_bitrate: "128k").to_s.should eq("-b:a 128k")
       end
 
       it "should use k unit for audio bitrate" do
-        EncodingOptions.new(audio_bitrate: 128).to_s.should == "-b:a 128k"
+        EncodingOptions.new(audio_bitrate: 128).to_s.should eq("-b:a 128k")
       end
 
       it "should convert audio sample rate" do
-        EncodingOptions.new(audio_sample_rate: 44100).to_s.should == "-ar 44100"
+        EncodingOptions.new(audio_sample_rate: 44100).to_s.should eq("-ar 44100")
       end
 
       it "should convert audio channels" do
-        EncodingOptions.new(audio_channels: 2).to_s.should == "-ac 2"
+        EncodingOptions.new(audio_channels: 2).to_s.should eq("-ac 2")
       end
 
       it "should convert maximum video bitrate" do
-        EncodingOptions.new(video_max_bitrate: 600).to_s.should == "-maxrate 600k"
+        EncodingOptions.new(video_max_bitrate: 600).to_s.should eq("-maxrate 600k")
       end
 
       it "should convert mininimum video bitrate" do
-        EncodingOptions.new(video_min_bitrate: 600).to_s.should == "-minrate 600k"
+        EncodingOptions.new(video_min_bitrate: 600).to_s.should eq("-minrate 600k")
       end
 
       it "should convert video bitrate tolerance" do
-        EncodingOptions.new(video_bitrate_tolerance: 100).to_s.should == "-bt 100k"
+        EncodingOptions.new(video_bitrate_tolerance: 100).to_s.should eq("-bt 100k")
       end
 
       it "should convert buffer size" do
-        EncodingOptions.new(buffer_size: 2000).to_s.should == "-bufsize 2000k"
+        EncodingOptions.new(buffer_size: 2000).to_s.should eq("-bufsize 2000k")
       end
 
       it "should convert threads" do
-        EncodingOptions.new(threads: 2).to_s.should == "-threads 2"
+        EncodingOptions.new(threads: 2).to_s.should eq("-threads 2")
       end
 
       it "should convert duration" do
-        EncodingOptions.new(duration: 30).to_s.should == "-t 30"
+        EncodingOptions.new(duration: 30).to_s.should eq("-t 30")
       end
 
       it "should convert keyframe interval" do
-        EncodingOptions.new(keyframe_interval: 60).to_s.should == "-g 60"
+        EncodingOptions.new(keyframe_interval: 60).to_s.should eq("-g 60")
       end
 
       it "should convert video preset" do
-        EncodingOptions.new(video_preset: "max").to_s.should == "-vpre max"
+        EncodingOptions.new(video_preset: "max").to_s.should eq("-vpre max")
       end
 
       it "should convert audio preset" do
-        EncodingOptions.new(audio_preset: "max").to_s.should == "-apre max"
+        EncodingOptions.new(audio_preset: "max").to_s.should eq("-apre max")
       end
 
       it "should convert file preset" do
-        EncodingOptions.new(file_preset: "max.ffpreset").to_s.should == "-fpre max.ffpreset"
+        EncodingOptions.new(file_preset: "max.ffpreset").to_s.should eq("-fpre max.ffpreset")
       end
 
       it "should specify seek time" do
-        EncodingOptions.new(seek_time: 1).to_s.should == "-ss 1"
+        EncodingOptions.new(seek_time: 1).to_s.should eq("-ss 1")
       end
 
       it 'should specify screenshot parameters when using -vframes' do
-        EncodingOptions.new(screenshot: true, vframes: 123).to_s.should == '-vframes 123 -f image2 '
+        EncodingOptions.new(screenshot: true, vframes: 123).to_s.should eq('-vframes 123 -f image2 ')
       end
 
       it "should specify screenshot parameters" do
-        EncodingOptions.new(screenshot: true).to_s.should == "-vframes 1 -f image2"
+        EncodingOptions.new(screenshot: true).to_s.should eq("-vframes 1 -f image2")
       end
 
       it "should put the parameters in order of codecs, presets, others" do
@@ -129,12 +129,12 @@ module FFMPEG
         opts[:video_preset] = "normal"
 
         converted = EncodingOptions.new(opts).to_s
-        converted.should == "-vcodec libx264 -vpre normal -r 25"
+        converted.should eq("-vcodec libx264 -vpre normal -r 25")
       end
 
       it "correctly identifies the input parameter" do
         converted = EncodingOptions.new({ input: 'somefile.mp4', custom: '-pass 1 passlogfile bla-i-bla' }).to_s
-        converted.should == "-i somefile.mp4 -pass 1 passlogfile bla-i-bla"
+        converted.should eq("-i somefile.mp4 -pass 1 passlogfile bla-i-bla")
       end
 
       it "should convert a lot of them simultaneously" do
@@ -143,19 +143,19 @@ module FFMPEG
       end
 
       it "should ignore options with nil value" do
-        EncodingOptions.new(video_codec: "libx264", frame_rate: nil).to_s.should == "-vcodec libx264 "
+        EncodingOptions.new(video_codec: "libx264", frame_rate: nil).to_s.should eq("-vcodec libx264 ")
       end
 
       it "should convert x264 vprofile" do
-        EncodingOptions.new(x264_vprofile: "high").to_s.should == "-vprofile high"
+        EncodingOptions.new(x264_vprofile: "high").to_s.should eq("-vprofile high")
       end
 
       it "should convert x264 preset" do
-        EncodingOptions.new(x264_preset: "slow").to_s.should == "-preset slow"
+        EncodingOptions.new(x264_preset: "slow").to_s.should eq("-preset slow")
       end
 
       it "should specify input watermark file" do
-        EncodingOptions.new(watermark: "watermark.png").to_s.should == "-i watermark.png"
+        EncodingOptions.new(watermark: "watermark.png").to_s.should eq("-i watermark.png")
       end
 
       it "should specify watermark position at left top corner" do
@@ -188,6 +188,32 @@ module FFMPEG
         opts[:watermark_filter] = { position: "RB", padding_x: 10, padding_y: 10 }
         converted = EncodingOptions.new(opts).to_s
         converted.should include "overlay=x=main_w-overlay_w-10:y=main_h-overlay_h-10'"
+      end
+    end
+
+    describe "ffmpeg prefix arguments conversion" do
+      it "should combine prefix options with provided, custom only" do
+        opts = Hash.new
+        opts[:frame_rate] = 25
+        opts[:video_codec] = "libx264"
+        opts[:input] = "my_movie.mp4"
+        opts[:video_preset] = "normal"
+        prefix_opts = Hash.new
+        prefix_opts[:custom] = "-vsync 0 -hwaccel cuda -hwaccel_output_format cuda"
+        converted = EncodingOptions.new(opts, prefix_opts).to_s
+        converted.should eq("-vsync 0 -hwaccel cuda -hwaccel_output_format cuda -i my_movie.mp4 -vcodec libx264 -vpre normal -r 25")
+      end
+
+      it "should combine prefix options with provided, custom and converted options" do
+        opts = Hash.new
+        opts[:frame_rate] = 25
+        opts[:input] = "my_movie.mp4"
+        prefix_opts = Hash.new
+        prefix_opts[:custom] = "-vsync 0 -hwaccel cuda -hwaccel_output_format cuda"
+        prefix_opts[:video_codec] = "libx265"
+        prefix_opts[:video_preset] = "normal"
+        converted = EncodingOptions.new(opts, prefix_opts).to_s
+        converted.should eq("-vsync 0 -hwaccel cuda -hwaccel_output_format cuda -vcodec libx265 -vpre normal -i my_movie.mp4 -r 25")
       end
     end
   end

--- a/spec/ffmpeg/movie_spec.rb
+++ b/spec/ffmpeg/movie_spec.rb
@@ -394,7 +394,7 @@ module FFMPEG
       end
 
       it "should parse the rotation" do
-        @movie.rotation.should == 90
+        @movie.rotation.should == -90
       end
     end
 

--- a/spec/ffmpeg/movie_spec.rb
+++ b/spec/ffmpeg/movie_spec.rb
@@ -404,11 +404,11 @@ module FFMPEG
 
         transcoder_double = double(Transcoder)
         Transcoder.should_receive(:new).
-          with(movie, "#{tmp_path}/awesome.flv", {custom: "-vcodec libx264"}, preserve_aspect_ratio: :width).
+          with(movie, "#{tmp_path}/awesome.flv", {custom: "-vcodec libx264"}, {preserve_aspect_ratio: :width}, {}).
           and_return(transcoder_double)
         transcoder_double.should_receive(:run)
 
-        movie.transcode("#{tmp_path}/awesome.flv", {custom: "-vcodec libx264"}, preserve_aspect_ratio: :width)
+        movie.transcode("#{tmp_path}/awesome.flv", {custom: "-vcodec libx264"}, {preserve_aspect_ratio: :width})
       end
     end
 
@@ -418,11 +418,11 @@ module FFMPEG
 
         transcoder_double = double(Transcoder)
         Transcoder.should_receive(:new).
-          with(movie, "#{tmp_path}/awesome.jpg", {seek_time: 2, dimensions: "640x480", screenshot: true}, preserve_aspect_ratio: :width).
+          with(movie, "#{tmp_path}/awesome.jpg", {seek_time: 2, dimensions: "640x480", screenshot: true}, {preserve_aspect_ratio: :width}, {}).
           and_return(transcoder_double)
         transcoder_double.should_receive(:run)
 
-        movie.screenshot("#{tmp_path}/awesome.jpg", {seek_time: 2, dimensions: "640x480"}, preserve_aspect_ratio: :width)
+        movie.screenshot("#{tmp_path}/awesome.jpg", {seek_time: 2, dimensions: "640x480"}, {preserve_aspect_ratio: :width})
       end
     end
   end


### PR DESCRIPTION
![](https://media.giphy.com/media/9058ZMj6ooluP4UUPl/giphy.gif)

## Description
As part of investigating adding GPU support, we realized the current ffmpeg library does not allow us to add pre-input/prefix options, which are required to add things such as `ffmpeg -y -vsync 0 -hwaccel cuda -hwaccel_output_format cuda`

This also bumps a dependabot alert, and corrects the rotation fetching for modern ffmpeg implementations