### PR TITLE
[CRAP-324] Enable Hide Banner Flags

### DIFF
--- a/lib/ffmpeg/black_detect.rb
+++ b/lib/ffmpeg/black_detect.rb
@@ -15,7 +15,7 @@ module FFMPEG
 
     def run
       # ffmpeg will output to stderr
-      command = "#{FFMPEG.ffprobe_binary} -f lavfi -i \"movie=#{Shellwords.escape(@movie.path)},blackdetect[out0]\" -show_entries tags=lavfi.black_start,lavfi.black_end -of default=nw=1 -v quiet"
+      command = "#{FFMPEG.ffprobe_binary} -hide_banner -f lavfi -i \"movie=#{Shellwords.escape(@movie.path)},blackdetect[out0]\" -show_entries tags=lavfi.black_start,lavfi.black_end -of default=nw=1 -v quiet"
       std_output = ''
       std_error = ''
 

--- a/lib/ffmpeg/movie.rb
+++ b/lib/ffmpeg/movie.rb
@@ -21,13 +21,13 @@ module FFMPEG
       @path = path
 
       if @path.end_with?('.m3u8')
-        optional_arguements = ' -allowed_extensions ALL'
+        optional_arguements = '-allowed_extensions ALL'
       else
         optional_arguements = ''
       end
 
       # ffmpeg will output to stderr
-      command = "#{FFMPEG.ffprobe_binary}#{optional_arguements} -i #{Shellwords.escape(path)} -print_format json -show_format -show_streams -show_error"
+      command = "#{FFMPEG.ffprobe_binary} -hide_banner #{optional_arguements} -i #{Shellwords.escape(path)} -print_format json -show_format -show_streams -show_error"
       spawn = POSIX::Spawn::Child.new(command)
 
       std_output = spawn.out

--- a/lib/ffmpeg/transcoder.rb
+++ b/lib/ffmpeg/transcoder.rb
@@ -58,7 +58,7 @@ module FFMPEG
     private
     # frame= 4855 fps= 46 q=31.0 size=   45306kB time=00:02:42.28 bitrate=2287.0kbits/
     def transcode_movie
-      @command = "#{FFMPEG.ffmpeg_binary} -y #{@raw_options} #{Shellwords.escape(@output_file)}"
+      @command = "#{FFMPEG.ffmpeg_binary} -hide_banner -y #{@raw_options} #{Shellwords.escape(@output_file)}"
       FFMPEG.logger.info("Running transcoding...\n#{@command}\n")
       @output = ""
 

--- a/spec/ffmpeg/movie_spec.rb
+++ b/spec/ffmpeg/movie_spec.rb
@@ -248,7 +248,7 @@ module FFMPEG
         end
 
         it "should parse the bitrate" do
-          expect(@movie.bitrate).to eq(481846)
+          expect(@movie.bitrate).to eq(481836)
         end
 
         it "should return nil rotation when no rotation exists" do


### PR DESCRIPTION
![](https://media4.giphy.com/media/l2Je7bPpjKbGJqSUo/giphy.gif)

## Description
Hide the version/copyright/library banners as they aren't providing any value at present and just waste a lot of log space / make it harder to narrow down.

## Testing
`rspec` passes locally