### PR TITLE
[CRAP-329] Increase Analyze Duration From Default 5s To 10s

### DIFF
--- a/lib/ffmpeg/black_detect.rb
+++ b/lib/ffmpeg/black_detect.rb
@@ -15,7 +15,7 @@ module FFMPEG
 
     def run
       # ffmpeg will output to stderr
-      command = "#{FFMPEG.ffprobe_binary} -hide_banner -f lavfi -i \"movie=#{Shellwords.escape(@movie.path)},blackdetect[out0]\" -show_entries tags=lavfi.black_start,lavfi.black_end -of default=nw=1 -v quiet"
+      command = "#{FFMPEG.ffprobe_binary} -hide_banner -analyzeduration 10000000 -probesize 10000000 -f lavfi -i \"movie=#{Shellwords.escape(@movie.path)},blackdetect[out0]\" -show_entries tags=lavfi.black_start,lavfi.black_end -of default=nw=1 -v quiet"
       std_output = ''
       std_error = ''
 

--- a/lib/ffmpeg/movie.rb
+++ b/lib/ffmpeg/movie.rb
@@ -27,7 +27,7 @@ module FFMPEG
       end
 
       # ffmpeg will output to stderr
-      command = "#{FFMPEG.ffprobe_binary} -hide_banner #{optional_arguements} -i #{Shellwords.escape(path)} -print_format json -show_format -show_streams -show_error"
+      command = "#{FFMPEG.ffprobe_binary} -hide_banner -analyzeduration 10000000 -probesize 10000000 #{optional_arguements} -i #{Shellwords.escape(path)} -print_format json -show_format -show_streams -show_error"
       spawn = POSIX::Spawn::Child.new(command)
 
       std_output = spawn.out

--- a/lib/ffmpeg/transcoder.rb
+++ b/lib/ffmpeg/transcoder.rb
@@ -99,7 +99,7 @@ module FFMPEG
       else
         errors = "Errors: #{@errors.join(", ")}. "
         FFMPEG.logger.error "Failed encoding...\n#{@command}\n\n#{@output}\n#{errors}\n"
-        raise Error, "Failed encoding.#{errors} Full output: #{@output}"
+        raise Error, "Failed encoding. #{errors} Full output: #{@output}"
       end
     end
 

--- a/lib/ffmpeg/transcoder.rb
+++ b/lib/ffmpeg/transcoder.rb
@@ -58,7 +58,7 @@ module FFMPEG
     private
     # frame= 4855 fps= 46 q=31.0 size=   45306kB time=00:02:42.28 bitrate=2287.0kbits/
     def transcode_movie
-      @command = "#{FFMPEG.ffmpeg_binary} -hide_banner -y #{@raw_options} #{Shellwords.escape(@output_file)}"
+      @command = "#{FFMPEG.ffmpeg_binary} -hide_banner -y -analyzeduration 10000000 -probesize 10000000 #{@raw_options} #{Shellwords.escape(@output_file)}"
       FFMPEG.logger.info("Running transcoding...\n#{@command}\n")
       @output = ""
 
@@ -99,7 +99,7 @@ module FFMPEG
       else
         errors = "Errors: #{@errors.join(", ")}. "
         FFMPEG.logger.error "Failed encoding...\n#{@command}\n\n#{@output}\n#{errors}\n"
-        raise Error, "Failed encoding.#{errors}Full output: #{@output}"
+        raise Error, "Failed encoding.#{errors} Full output: #{@output}"
       end
     end
 


### PR DESCRIPTION
![](https://media1.giphy.com/media/F3BeiZNq6VbDwyxzxF/giphy.gif)

## Description
At present this package defaults to the "normal" 5 second analyze duration, and this bumps it up to 10 seconds instead.

Relating to [CRAP-329](https://vidyard.atlassian.net/browse/CRAP-329)

[CRAP-329]: https://vidyard.atlassian.net/browse/CRAP-329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ