### PR TITLE
CRT-93 Add parameters to Movie for specifying analyzeduration and probesize

### DIFF
--- a/lib/ffmpeg/black_detect.rb
+++ b/lib/ffmpeg/black_detect.rb
@@ -15,7 +15,7 @@ module FFMPEG
 
     def run
       # ffmpeg will output to stderr
-      command = "#{FFMPEG.ffprobe_binary} -hide_banner -analyzeduration 10000000 -probesize 10000000 -f lavfi -i \"movie=#{Shellwords.escape(@movie.path)},blackdetect[out0]\" -show_entries tags=lavfi.black_start,lavfi.black_end -of default=nw=1 -v quiet"
+      command = "#{@movie.ffprobe_command} -f lavfi -i \"movie=#{Shellwords.escape(@movie.path)},blackdetect[out0]\" -show_entries tags=lavfi.black_start,lavfi.black_end -of default=nw=1 -v quiet"
       std_output = ''
       std_error = ''
 
@@ -55,7 +55,7 @@ module FFMPEG
       end
 
       if std_error != ''
-        @invalid = true 
+        @invalid = true
         FFMPEG.logger.error(std_error)
       end
 

--- a/lib/ffmpeg/movie.rb
+++ b/lib/ffmpeg/movie.rb
@@ -4,7 +4,7 @@ require 'posix-spawn'
 
 module FFMPEG
   class Movie
-    attr_reader :path, :duration, :time, :bitrate, :rotation, :creation_time
+    attr_reader :path, :duration, :time, :bitrate, :rotation, :creation_time, :analyzeduration, :probesize
     attr_reader :video_stream, :video_codec, :video_bitrate, :colorspace, :width, :height, :sar, :dar, :frame_rate, :has_b_frames, :video_profile, :video_level
     attr_reader :audio_streams, :audio_stream, :audio_codec, :audio_bitrate, :audio_sample_rate, :audio_channels, :audio_tags
     attr_reader :color_primaries, :avframe_color_space, :color_transfer

--- a/lib/ffmpeg/movie.rb
+++ b/lib/ffmpeg/movie.rb
@@ -143,7 +143,15 @@ module FFMPEG
       end
     end
 
-    def ffprobe_command(binary = FFMPEG.ffprobe_binary)
+    def ffprobe_command()
+      ff_command(FFMPEG.ffprobe_binary)
+    end
+
+    def ffmpeg_command()
+      ff_command(FFMPEG.ffmpeg_binary)
+    end
+
+    def ff_command(binary = FFMPEG.ffmpeg_binary)
       "#{binary} -hide_banner -analyzeduration #{@analyzeduration} -probesize #{@probesize}"
     end
 

--- a/lib/ffmpeg/movie.rb
+++ b/lib/ffmpeg/movie.rb
@@ -151,7 +151,7 @@ module FFMPEG
       ff_command(FFMPEG.ffmpeg_binary)
     end
 
-    def ff_command(binary = FFMPEG.ffmpeg_binary)
+    def ff_command(binary)
       "#{binary} -hide_banner -analyzeduration #{@analyzeduration} -probesize #{@probesize}"
     end
 

--- a/lib/ffmpeg/movie.rb
+++ b/lib/ffmpeg/movie.rb
@@ -143,11 +143,11 @@ module FFMPEG
       end
     end
 
-    def ffprobe_command()
+    def ffprobe_command
       ff_command(FFMPEG.ffprobe_binary)
     end
 
-    def ffmpeg_command()
+    def ffmpeg_command
       ff_command(FFMPEG.ffmpeg_binary)
     end
 

--- a/lib/ffmpeg/movie.rb
+++ b/lib/ffmpeg/movie.rb
@@ -21,13 +21,13 @@ module FFMPEG
       @path = path
 
       if @path.end_with?('.m3u8')
-        optional_arguements = '-allowed_extensions ALL'
+        optional_arguments = '-allowed_extensions ALL'
       else
-        optional_arguements = ''
+        optional_arguments = ''
       end
 
       # ffmpeg will output to stderr
-      command = "#{FFMPEG.ffprobe_binary} -hide_banner -analyzeduration 10000000 -probesize 10000000 #{optional_arguements} -i #{Shellwords.escape(path)} -print_format json -show_format -show_streams -show_error"
+      command = "#{FFMPEG.ffprobe_binary} -hide_banner -analyzeduration 10000000 -probesize 10000000 #{optional_arguments} -i #{Shellwords.escape(path)} -print_format json -show_format -show_streams -show_error"
       spawn = POSIX::Spawn::Child.new(command)
 
       std_output = spawn.out
@@ -131,7 +131,7 @@ module FFMPEG
       std_err_codec_failure = std_error.include?("could not find codec parameters")
       FFMPEG.logger.error(std_error)
       if nil_or_unsupported_stream or metadata_error or std_err_codec_failure
-        @invalid = true 
+        @invalid = true
         FFMPEG.logger.error(
           nil_or_unsupported_stream: nil_or_unsupported_stream,
           metadata_error: metadata_error,

--- a/lib/ffmpeg/movie.rb
+++ b/lib/ffmpeg/movie.rb
@@ -13,7 +13,7 @@ module FFMPEG
 
     UNSUPPORTED_CODEC_PATTERN = /^Unsupported codec with id (\d+) for input stream (\d+)$/
 
-    def initialize(path)
+    def initialize(path, analyzeduration = 15000000, probesize=15000000 )
       unless File.exist?(path) || path =~ URI::regexp(["http", "https"])
         raise Errno::ENOENT, "the file '#{path}' does not exist"
       end
@@ -27,7 +27,7 @@ module FFMPEG
       end
 
       # ffmpeg will output to stderr
-      command = "#{FFMPEG.ffprobe_binary} -hide_banner -analyzeduration 10000000 -probesize 10000000 #{optional_arguments} -i #{Shellwords.escape(path)} -print_format json -show_format -show_streams -show_error"
+      command = "#{FFMPEG.ffprobe_binary} -hide_banner -analyzeduration #{analyzeduration} -probesize #{probesize} #{optional_arguments} -i #{Shellwords.escape(path)} -print_format json -show_format -show_streams -show_error"
       spawn = POSIX::Spawn::Child.new(command)
 
       std_output = spawn.out

--- a/lib/ffmpeg/movie.rb
+++ b/lib/ffmpeg/movie.rb
@@ -19,6 +19,8 @@ module FFMPEG
       end
 
       @path = path
+      @analyzeduration = analyzeduration;
+      @probesize = probesize;
 
       if @path.end_with?('.m3u8')
         optional_arguments = '-allowed_extensions ALL'
@@ -27,7 +29,7 @@ module FFMPEG
       end
 
       # ffmpeg will output to stderr
-      command = "#{FFMPEG.ffprobe_binary} -hide_banner -analyzeduration #{analyzeduration} -probesize #{probesize} #{optional_arguments} -i #{Shellwords.escape(path)} -print_format json -show_format -show_streams -show_error"
+      command = "#{ffprobe_command} #{optional_arguments} -i #{Shellwords.escape(path)} -print_format json -show_format -show_streams -show_error"
       spawn = POSIX::Spawn::Child.new(command)
 
       std_output = spawn.out
@@ -139,6 +141,10 @@ module FFMPEG
           std_error: std_error
         )
       end
+    end
+
+    def ffprobe_command(binary = FFMPEG.ffprobe_binary)
+      "#{binary} -hide_banner -analyzeduration #{@analyzeduration} -probesize #{@probesize}"
     end
 
     def unsupported_streams(std_error)

--- a/lib/ffmpeg/transcoder.rb
+++ b/lib/ffmpeg/transcoder.rb
@@ -58,7 +58,8 @@ module FFMPEG
     private
     # frame= 4855 fps= 46 q=31.0 size=   45306kB time=00:02:42.28 bitrate=2287.0kbits/
     def transcode_movie
-      @command = "#{FFMPEG.ffmpeg_binary} -hide_banner -y -analyzeduration 10000000 -probesize 10000000 #{@raw_options} #{Shellwords.escape(@output_file)}"
+      @command = "#{@movie.ffprobe_command(FFMPEG.ffmpeg_binary)} -y #{@raw_options} #{Shellwords.escape(@output_file)}"
+
       FFMPEG.logger.info("Running transcoding...\n#{@command}\n")
       @output = ""
 

--- a/lib/ffmpeg/transcoder.rb
+++ b/lib/ffmpeg/transcoder.rb
@@ -58,7 +58,7 @@ module FFMPEG
     private
     # frame= 4855 fps= 46 q=31.0 size=   45306kB time=00:02:42.28 bitrate=2287.0kbits/
     def transcode_movie
-      @command = "#{@movie.ffprobe_command(FFMPEG.ffmpeg_binary)} -y #{@raw_options} #{Shellwords.escape(@output_file)}"
+      @command = "#{@movie.ffmpeg_command} -y #{@raw_options} #{Shellwords.escape(@output_file)}"
 
       FFMPEG.logger.info("Running transcoding...\n#{@command}\n")
       @output = ""

--- a/spec/ffmpeg/movie_spec.rb
+++ b/spec/ffmpeg/movie_spec.rb
@@ -411,13 +411,9 @@ module FFMPEG
       end
     end
 
-    def mock_file_io(movie, path)
-
-    end
-
     describe 'ffprobe & ffmpeg command' do
       it 'returns the ffprobe command with default analyzeduration and probesize values' do
-        allow(File).to receive(:exist?).with("").and_return(true)
+        allow(File).to receive(:exist?).and_return(true)
         movie = FFMPEG::Movie.new("")
         expect(movie.ffprobe_command).to eq("#{FFMPEG.ffprobe_binary} -hide_banner -analyzeduration 15000000 -probesize 15000000")
       end
@@ -426,13 +422,13 @@ module FFMPEG
         analyzeduration = 5000000
         probesize = 1000000
 
-        allow(File).to receive(:exist?).with("").and_return(true)
+        allow(File).to receive(:exist?).and_return(true)
         movie = FFMPEG::Movie.new("", analyzeduration = analyzeduration, probesize = probesize)
         expect(movie.ffprobe_command).to eq("#{FFMPEG.ffprobe_binary} -hide_banner -analyzeduration #{analyzeduration} -probesize #{probesize}")
       end
 
       it 'returns the ffmpeg command with default analyzeduration and probesize values' do
-        allow(File).to receive(:exist?).with("").and_return(true)
+        allow(File).to receive(:exist?).and_return(true)
         movie = FFMPEG::Movie.new("")
         expect(movie.ffmpeg_command).to eq("#{FFMPEG.ffmpeg_binary} -hide_banner -analyzeduration 15000000 -probesize 15000000")
       end
@@ -441,7 +437,7 @@ module FFMPEG
         analyzeduration = 5000000
         probesize = 1000000
 
-        allow(File).to receive(:exist?).with("").and_return(true)
+        allow(File).to receive(:exist?).and_return(true)
         movie = FFMPEG::Movie.new("", analyzeduration = analyzeduration, probesize = probesize)
         expect(movie.ffmpeg_command).to eq("#{FFMPEG.ffmpeg_binary} -hide_banner -analyzeduration #{analyzeduration} -probesize #{probesize}")
       end

--- a/spec/ffmpeg/movie_spec.rb
+++ b/spec/ffmpeg/movie_spec.rb
@@ -421,7 +421,7 @@ module FFMPEG
         analyzeduration = 5000000
         probesize = 1000000
 
-        movie = FFMPEG::Movie.new("#{fixture_path}/movies/awesome movie.mov", analyzeduration= analyzeduration, probesize= probesize)
+        movie = FFMPEG::Movie.new("#{fixture_path}/movies/awesome movie.mov", analyzeduration = analyzeduration, probesize = probesize)
         expect(movie.ffprobe_command).to eq("#{FFMPEG.ffprobe_binary} -hide_banner -analyzeduration #{analyzeduration} -probesize #{probesize}")
       end
     end
@@ -436,7 +436,7 @@ module FFMPEG
         analyzeduration = 5000000
         probesize = 1000000
 
-        movie = FFMPEG::Movie.new("#{fixture_path}/movies/awesome movie.mov", analyzeduration= analyzeduration, probesize= probesize)
+        movie = FFMPEG::Movie.new("#{fixture_path}/movies/awesome movie.mov", analyzeduration = analyzeduration, probesize = probesize)
         expect(movie.ffmpeg_command).to eq("#{FFMPEG.ffmpeg_binary} -hide_banner -analyzeduration #{analyzeduration} -probesize #{probesize}")
       end
     end

--- a/spec/ffmpeg/movie_spec.rb
+++ b/spec/ffmpeg/movie_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper.rb'
 
 module FFMPEG
   describe Movie do
+
     describe "initializing" do
       context "given a non existing file" do
         it "should throw ArgumentError" do
@@ -407,6 +408,30 @@ module FFMPEG
         expect(transcoder_double).to receive(:run)
 
         movie.transcode("#{tmp_path}/awesome.flv", {custom: "-vcodec libx264"}, {preserve_aspect_ratio: :width})
+      end
+    end
+
+    describe '#ffprobe_command' do
+      it 'returns the ffprobe command with default analyzeduration and probesize values' do
+        movie = FFMPEG::Movie.new("#{fixture_path}/movies/awesome movie.mov")
+        expect(movie.ffprobe_command).to eq("#{FFMPEG.ffprobe_binary} -hide_banner -analyzeduration 15000000 -probesize 15000000")
+      end
+
+      it 'returns the ffprobe command with custom analyzeduration and probesize values' do
+        movie = FFMPEG::Movie.new("#{fixture_path}/movies/awesome movie.mov", analyzeduration: 5000000, probesize: 1000000)
+        expect(movie.ffprobe_command).to eq("#{FFMPEG.ffprobe_binary} -hide_banner -analyzeduration 5000000 -probesize 1000000")
+      end
+    end
+
+    describe '#ffmpeg_command' do
+      it 'returns the ffmpeg command with default analyzeduration and probesize values' do
+        movie = FFMPEG::Movie.new("#{fixture_path}/movies/awesome movie.mov")
+        expect(movie.ffmpeg_command).to eq("#{FFMPEG.ffmpeg_binary} -hide_banner -analyzeduration 15000000 -probesize 15000000")
+      end
+
+      it 'returns the ffmpeg command with custom analyzeduration and probesize values' do
+        movie = FFMPEG::Movie.new("#{fixture_path}/movies/awesome movie.mov", analyzeduration: 5000000, probesize: 1000000)
+        expect(movie.ffmpeg_command).to eq("#{FFMPEG.ffmpeg_binary} -hide_banner -analyzeduration 5000000 -probesize 1000000")
       end
     end
 

--- a/spec/ffmpeg/movie_spec.rb
+++ b/spec/ffmpeg/movie_spec.rb
@@ -419,8 +419,8 @@ module FFMPEG
       end
 
       it 'returns the ffprobe command with custom analyzeduration and probesize values' do
-        analyzeduration = 5000000
-        probesize = 1000000
+        analyze_duration = 5000000
+        probe_size = 1000000
 
         allow(File).to receive(:exist?).and_return(true)
         movie = FFMPEG::Movie.new("", analyzeduration = analyzeduration, probesize = probesize)
@@ -440,6 +440,16 @@ module FFMPEG
         allow(File).to receive(:exist?).and_return(true)
         movie = FFMPEG::Movie.new("", analyzeduration = analyzeduration, probesize = probesize)
         expect(movie.ffmpeg_command).to eq("#{FFMPEG.ffmpeg_binary} -hide_banner -analyzeduration #{analyzeduration} -probesize #{probesize}")
+      end
+
+      it 'it allows getting the analyzeduration and probesize as an attr' do
+        analyzeduration = 2000000
+        probesize = 3000000
+
+        allow(File).to receive(:exist?).and_return(true)
+        movie = FFMPEG::Movie.new("", analyzeduration = analyzeduration, probesize = probesize)
+        expect(movie.analyzeduration).to eq(analyzeduration)
+        expect(movie.probesize).to eq(probesize)
       end
     end
 

--- a/spec/ffmpeg/movie_spec.rb
+++ b/spec/ffmpeg/movie_spec.rb
@@ -411,9 +411,14 @@ module FFMPEG
       end
     end
 
-    describe '#ffprobe_command' do
+    def mock_file_io(movie, path)
+
+    end
+
+    describe 'ffprobe & ffmpeg command' do
       it 'returns the ffprobe command with default analyzeduration and probesize values' do
-        movie = FFMPEG::Movie.new("#{fixture_path}/movies/awesome movie.mov")
+        allow(File).to receive(:exist?).with("").and_return(true)
+        movie = FFMPEG::Movie.new("")
         expect(movie.ffprobe_command).to eq("#{FFMPEG.ffprobe_binary} -hide_banner -analyzeduration 15000000 -probesize 15000000")
       end
 
@@ -421,14 +426,14 @@ module FFMPEG
         analyzeduration = 5000000
         probesize = 1000000
 
-        movie = FFMPEG::Movie.new("#{fixture_path}/movies/awesome movie.mov", analyzeduration = analyzeduration, probesize = probesize)
+        allow(File).to receive(:exist?).with("").and_return(true)
+        movie = FFMPEG::Movie.new("", analyzeduration = analyzeduration, probesize = probesize)
         expect(movie.ffprobe_command).to eq("#{FFMPEG.ffprobe_binary} -hide_banner -analyzeduration #{analyzeduration} -probesize #{probesize}")
       end
-    end
 
-    describe '#ffmpeg_command' do
       it 'returns the ffmpeg command with default analyzeduration and probesize values' do
-        movie = FFMPEG::Movie.new("#{fixture_path}/movies/awesome movie.mov")
+        allow(File).to receive(:exist?).with("").and_return(true)
+        movie = FFMPEG::Movie.new("")
         expect(movie.ffmpeg_command).to eq("#{FFMPEG.ffmpeg_binary} -hide_banner -analyzeduration 15000000 -probesize 15000000")
       end
 
@@ -436,7 +441,8 @@ module FFMPEG
         analyzeduration = 5000000
         probesize = 1000000
 
-        movie = FFMPEG::Movie.new("#{fixture_path}/movies/awesome movie.mov", analyzeduration = analyzeduration, probesize = probesize)
+        allow(File).to receive(:exist?).with("").and_return(true)
+        movie = FFMPEG::Movie.new("", analyzeduration = analyzeduration, probesize = probesize)
         expect(movie.ffmpeg_command).to eq("#{FFMPEG.ffmpeg_binary} -hide_banner -analyzeduration #{analyzeduration} -probesize #{probesize}")
       end
     end

--- a/spec/ffmpeg/movie_spec.rb
+++ b/spec/ffmpeg/movie_spec.rb
@@ -421,8 +421,8 @@ module FFMPEG
         analyzeduration = 5000000
         probesize = 1000000
 
-        movie = FFMPEG::Movie.new("#{fixture_path}/movies/awesome movie.mov", analyzeduration: analyzeduration, probesize: probesize)
-        expect(movie.ffprobe_command).to eq("#{FFMPEG.ffprobe_binary} -hide_banner -analyzeduration #{analyzeduration} -probesize #{probesize}}")
+        movie = FFMPEG::Movie.new("#{fixture_path}/movies/awesome movie.mov", analyzeduration= analyzeduration, probesize= probesize)
+        expect(movie.ffprobe_command).to eq("#{FFMPEG.ffprobe_binary} -hide_banner -analyzeduration #{analyzeduration} -probesize #{probesize}")
       end
     end
 
@@ -436,8 +436,8 @@ module FFMPEG
         analyzeduration = 5000000
         probesize = 1000000
 
-        movie = FFMPEG::Movie.new("#{fixture_path}/movies/awesome movie.mov", analyzeduration: analyzeduration, probesize: probesize)
-        expect(movie.ffmpeg_command).to eq("#{FFMPEG.ffmpeg_binary} -hide_banner -analyzeduration -analyzeduration #{analyzeduration} -probesize #{probesize}}")
+        movie = FFMPEG::Movie.new("#{fixture_path}/movies/awesome movie.mov", analyzeduration= analyzeduration, probesize= probesize)
+        expect(movie.ffmpeg_command).to eq("#{FFMPEG.ffmpeg_binary} -hide_banner -analyzeduration #{analyzeduration} -probesize #{probesize}")
       end
     end
 

--- a/spec/ffmpeg/movie_spec.rb
+++ b/spec/ffmpeg/movie_spec.rb
@@ -418,8 +418,11 @@ module FFMPEG
       end
 
       it 'returns the ffprobe command with custom analyzeduration and probesize values' do
-        movie = FFMPEG::Movie.new("#{fixture_path}/movies/awesome movie.mov", analyzeduration: 5000000, probesize: 1000000)
-        expect(movie.ffprobe_command).to eq("#{FFMPEG.ffprobe_binary} -hide_banner -analyzeduration 5000000 -probesize 1000000")
+        analyzeduration = 5000000
+        probesize = 1000000
+
+        movie = FFMPEG::Movie.new("#{fixture_path}/movies/awesome movie.mov", analyzeduration: analyzeduration, probesize: probesize)
+        expect(movie.ffprobe_command).to eq("#{FFMPEG.ffprobe_binary} -hide_banner -analyzeduration #{analyzeduration} -probesize #{probesize}}")
       end
     end
 
@@ -430,8 +433,11 @@ module FFMPEG
       end
 
       it 'returns the ffmpeg command with custom analyzeduration and probesize values' do
-        movie = FFMPEG::Movie.new("#{fixture_path}/movies/awesome movie.mov", analyzeduration: 5000000, probesize: 1000000)
-        expect(movie.ffmpeg_command).to eq("#{FFMPEG.ffmpeg_binary} -hide_banner -analyzeduration 5000000 -probesize 1000000")
+        analyzeduration = 5000000
+        probesize = 1000000
+
+        movie = FFMPEG::Movie.new("#{fixture_path}/movies/awesome movie.mov", analyzeduration: analyzeduration, probesize: probesize)
+        expect(movie.ffmpeg_command).to eq("#{FFMPEG.ffmpeg_binary} -hide_banner -analyzeduration -analyzeduration #{analyzeduration} -probesize #{probesize}}")
       end
     end
 

--- a/spec/ffmpeg/movie_spec.rb
+++ b/spec/ffmpeg/movie_spec.rb
@@ -442,7 +442,7 @@ module FFMPEG
         expect(movie.ffmpeg_command).to eq("#{FFMPEG.ffmpeg_binary} -hide_banner -analyzeduration #{analyzeduration} -probesize #{probesize}")
       end
 
-      it 'it allows getting the analyzeduration and probesize as an attr' do
+      it 'allows getting the analyzeduration and probesize as an attr' do
         analyzeduration = 2000000
         probesize = 3000000
 


### PR DESCRIPTION
![](https://media2.giphy.com/media/xUPGcEw56dJj3fJFJe/giphy.gif)

## Description
At present this package defaults to 10 seconds analyze duration
This bumps the default to 15 seconds and adds parameters for customizing this

Relating to [CRT-93](https://vidyard.atlassian.net/browse/CRT-93)


## How Has This Been Tested?

### Manual Testing
- [ ] Manually in Playground
- [X] Manually in Staging
  <!-- Please describe the steps you took to manually test your changes. -->
  <!-- ##### Manual Testing Steps: -->
1. Start named staging with new defaults
2. Upload video that fails in prod
3. See it transcode correctly
4. In Vault, set evars to old default
5. Upload video again
6. See if fails to transcode

### Specs

#### _**(One below MUST be checked)**_

- [X] Specs added or updated
- [ ] This PR is an exception without tests 😐
  <!-- ##### Justification For No Test Changes -->
  <!-- - <Some really good justification> -->


[CRT-93]: https://vidyard.atlassian.net/browse/CRT-93?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ