### PR TITLE
[CRAP-349] Add Multi-Input Support To Base Library

### DIFF
--- a/lib/ffmpeg/black_detect.rb
+++ b/lib/ffmpeg/black_detect.rb
@@ -15,7 +15,7 @@ module FFMPEG
 
     def run
       # ffmpeg will output to stderr
-      command = "#{@movie.ffprobe_command} -f lavfi -i \"movie=#{Shellwords.escape(@movie.path)},blackdetect[out0]\" -show_entries tags=lavfi.black_start,lavfi.black_end -of default=nw=1 -v quiet"
+      command = "#{@movie.ffprobe_command} -f lavfi -i \"movie=#{@movie.path},blackdetect[out0]\" -show_entries tags=lavfi.black_start,lavfi.black_end -of default=nw=1 -v quiet"
       std_output = ''
       std_error = ''
 

--- a/lib/ffmpeg/encoding_options.rb
+++ b/lib/ffmpeg/encoding_options.rb
@@ -18,15 +18,16 @@ module FFMPEG
 
       # codecs should go before the presets so that the files will be matched successfully
       # all other parameters go after so that we can override whatever is in the preset
-      input   = params.select { |p| p =~ /^\-i / }
+      inputs   = params.select { |p| p =~ /^\-i / }
       seek    = params.select {|p| p =~ /\-ss/ }
       codecs  = params.select { |p| p =~ /codec/ }
       presets = params.select { |p| p =~ /\-.pre/ }
-      other   = params - codecs - presets - input - seek
-      params  = prefix_params + seek + input + codecs + presets + other
+      other   = params - codecs - presets - inputs - seek
+      params  = prefix_params + seek + inputs + codecs + presets + other
 
       params_string = params.join(" ")
       params_string << " #{convert_aspect(calculate_aspect)}" if calculate_aspect?
+
       params_string
     end
 
@@ -166,8 +167,13 @@ module FFMPEG
       value
     end
 
+    def convert_inputs(values)
+      "-i #{values.join('-i ')}"
+    end
+
+    # Deprecated, but accounting for "old" syntax
     def convert_input(value)
-      "-i #{Shellwords.escape(value)}"
+      convert_inputs([value])
     end
 
     def k_format(value)

--- a/lib/ffmpeg/encoding_options.rb
+++ b/lib/ffmpeg/encoding_options.rb
@@ -18,10 +18,10 @@ module FFMPEG
 
       # codecs should go before the presets so that the files will be matched successfully
       # all other parameters go after so that we can override whatever is in the preset
-      inputs   = params.select { |p| p =~ /\-i / }
-      seek    = params.select {|p| p =~ /\-ss/ }
-      codecs  = params.select { |p| p =~ /codec/ }
-      presets = params.select { |p| p =~ /\-.pre/ }
+      inputs                    = params.select { |p| p =~ /\-i / }
+      seek                      = params.select {|p| p =~ /\-ss/ }
+      codecs                    = params.select { |p| p =~ /codec/ }
+      presets                   = params.select { |p| p =~ /\-.pre/ }
       contains_complex_filter   = params.any? { |p| p =~ /\-filter_complex / }
 
       other   = params - codecs - presets - inputs - seek

--- a/lib/ffmpeg/encoding_options.rb
+++ b/lib/ffmpeg/encoding_options.rb
@@ -7,6 +7,7 @@ module FFMPEG
       merge!(options)
     end
 
+    # Returns the full subset of options any time a string is requested
     def to_s
       params = collect do |key, value|
         attempt_self_call(key, value)
@@ -39,6 +40,8 @@ module FFMPEG
       params_string
     end
 
+    # Returns a subset of the full encoding options, and must be requested explicitly
+    # Specifically useful for the pre-encode step which does not want the complex filters
     def to_s_minimal
       params = collect do |key, value|
         attempt_self_call(key, value)

--- a/lib/ffmpeg/encoding_options.rb
+++ b/lib/ffmpeg/encoding_options.rb
@@ -84,7 +84,7 @@ module FFMPEG
       final_grouping = ''
 
       num_inputs.times do |index|
-        input_forming += "[#{index}:v]scale,crop,transpose,setpts=PTS-STARTPTS[v#{index}];"
+        input_forming += "[#{index}:v]setpts=PTS-STARTPTS[v#{index}];"
         # TODO support audio-less videos by checking if any streams exist
         final_grouping += "[v#{index}][#{index}:a]"
       end

--- a/lib/ffmpeg/encoding_options.rb
+++ b/lib/ffmpeg/encoding_options.rb
@@ -61,24 +61,6 @@ module FFMPEG
       params_string
     end
 
-    # def default_multi_input_complex_filter(num_inputs)
-    #   initial_input_forming = '[0][1]scale2ref[canvas][vid1];'
-    #   canvas_splitting = "[canvas]split=#{num_inputs}"
-    #   canvas_creations = ''
-    #   final_grouping = ''
-
-    #   num_inputs.times do |index|
-    #     offset_index = index + 1
-    #     initial_input_forming += "[canvas][#{offset_index}]scale2ref='max(iw,main_w)':'max(ih,main_h)'[canvas][vid#{offset_index}];" if index > 0 #skip initial index since it has different formatting
-    #     canvas_splitting += "[canvas#{offset_index}]"
-    #     canvas_creations += "[canvas#{offset_index}][vid#{offset_index}]overlay=x='(W-w)/2':y='(H-h)/2':shortest=1[vid#{offset_index}];"
-    #     final_grouping += "[vid#{offset_index}]"
-    #   end
-
-    #   final_grouping += "concat=n=#{num_inputs}:v=1,setsar=1"
-    #   return "#{initial_input_forming}#{canvas_splitting};#{canvas_creations}#{final_grouping}"
-    # end
-
     def default_multi_input_complex_filter(num_inputs)
       input_forming = ''
       final_grouping = ''

--- a/lib/ffmpeg/encoding_options.rb
+++ b/lib/ffmpeg/encoding_options.rb
@@ -39,6 +39,28 @@ module FFMPEG
       params_string
     end
 
+    def to_s_minimal
+      params = collect do |key, value|
+        attempt_self_call(key, value)
+      end
+
+      # codecs should go before the presets so that the files will be matched successfully
+      # all other parameters go after so that we can override whatever is in the preset
+      inputs                    = params.select { |p| p =~ /\-i / }
+      seek                      = params.select {|p| p =~ /\-ss/ }
+      codecs                    = params.select { |p| p =~ /codec/ }
+      presets                   = params.select { |p| p =~ /\-.pre/ }
+      complex_filter            = params.select { |p| p =~ /\-filter_complex / }
+
+      other   = params - codecs - presets - inputs - seek - complex_filter
+      params  = codecs + presets + other
+
+      params_string = params.join(" ")
+      params_string << " #{convert_aspect(calculate_aspect)}" if calculate_aspect?
+
+      params_string
+    end
+
     # def default_multi_input_complex_filter(num_inputs)
     #   initial_input_forming = '[0][1]scale2ref[canvas][vid1];'
     #   canvas_splitting = "[canvas]split=#{num_inputs}"

--- a/lib/ffmpeg/movie.rb
+++ b/lib/ffmpeg/movie.rb
@@ -4,7 +4,7 @@ require 'posix-spawn'
 
 module FFMPEG
   class Movie
-    attr_reader :path, :paths, :unescaped_paths, :duration, :time, :bitrate, :rotation, :creation_time, :analyzeduration, :probesize
+    attr_reader :path, :paths, :unescaped_paths, :interim_paths, :duration, :time, :bitrate, :rotation, :creation_time, :analyzeduration, :probesize
     attr_reader :video_stream, :video_codec, :video_bitrate, :colorspace, :width, :height, :sar, :dar, :frame_rate, :has_b_frames, :video_profile, :video_level
     attr_reader :audio_streams, :audio_stream, :audio_codec, :audio_bitrate, :audio_sample_rate, :audio_channels, :audio_tags
     attr_reader :color_primaries, :avframe_color_space, :color_transfer
@@ -24,6 +24,7 @@ module FFMPEG
       end
 
       @paths = inputs
+      @interim_paths = []
       @analyzeduration = analyzeduration;
       @probesize = probesize;
 

--- a/lib/ffmpeg/movie.rb
+++ b/lib/ffmpeg/movie.rb
@@ -4,7 +4,7 @@ require 'posix-spawn'
 
 module FFMPEG
   class Movie
-    attr_reader :path, :paths, :duration, :time, :bitrate, :rotation, :creation_time, :analyzeduration, :probesize
+    attr_reader :path, :paths, :unescaped_paths, :duration, :time, :bitrate, :rotation, :creation_time, :analyzeduration, :probesize
     attr_reader :video_stream, :video_codec, :video_bitrate, :colorspace, :width, :height, :sar, :dar, :frame_rate, :has_b_frames, :video_profile, :video_level
     attr_reader :audio_streams, :audio_stream, :audio_codec, :audio_bitrate, :audio_sample_rate, :audio_channels, :audio_tags
     attr_reader :color_primaries, :avframe_color_space, :color_transfer
@@ -16,6 +16,7 @@ module FFMPEG
     def initialize(paths, analyzeduration = 15000000, probesize=15000000 )
       paths = [paths] unless paths.is_a? Array
 
+      @unescaped_paths = paths
       inputs = []
       paths.each do |path|
         raise Errno::ENOENT, "the file '#{path}' does not exist" unless File.exist?(path) || path =~ URI::regexp(["http", "https"])
@@ -214,6 +215,10 @@ module FFMPEG
 
     def path
       @paths.first
+    end
+
+    def unescaped_path
+      @unescaped_paths.first
     end
 
     def portrait?

--- a/lib/ffmpeg/movie.rb
+++ b/lib/ffmpeg/movie.rb
@@ -39,9 +39,6 @@ module FFMPEG
       command = "#{ffprobe_command} #{optional_arguments} -i #{@paths.first} -print_format json -show_format -show_streams -show_error"
       spawn = POSIX::Spawn::Child.new(command)
 
-      # sources = (inputs.length > 1) ? "-f concat -i #{escaped_paths.join " -i "})" : "-i #{escaped_paths.first}"
-      # spawn = POSIX::Spawn::Child.new(command)
-
       std_output = spawn.out
       std_error = spawn.err
 

--- a/lib/ffmpeg/transcoder.rb
+++ b/lib/ffmpeg/transcoder.rb
@@ -80,9 +80,12 @@ module FFMPEG
       output_frame_rate = [@raw_options[:frame_rate] || @movie.frame_rate, 30].max
       output_frame_rate = 30 if output_frame_rate > 300
 
+      # Add a subset of the full encode options
+      pre_encode_options = @raw_options.is_a?(EncodingOptions) ? @raw_options.to_s_minimal : @raw_options
+
       # Convert the individual videos into a common format, using the first video in as the "resolution"
       @movie.paths.each_with_index do |path, index|
-        command = "#{@movie.ffmpeg_command} -y -i #{path} -movflags faststart -r #{output_frame_rate} -filter_complex \"[0:v]scale=#{@movie.height}:#{@movie.width},setsar=1[Scaled]\" -map \"[Scaled]\" -map \"0:a\" #{@movie.interim_paths[index]}"
+        command = "#{@movie.ffmpeg_command} -y -i #{path} -movflags faststart #{pre_encode_options} -r #{output_frame_rate} -filter_complex \"[0:v]scale=#{@movie.height}:#{@movie.width},setsar=1[Scaled]\" -map \"[Scaled]\" -map \"0:a\" #{@movie.interim_paths[index]}"
 
         FFMPEG.logger.info("Running transcoding...\n#{command}\n")
         output = ""

--- a/lib/ffmpeg/transcoder.rb
+++ b/lib/ffmpeg/transcoder.rb
@@ -26,7 +26,7 @@ module FFMPEG
             FileUtils.mkdir_p(dirname)
           end
 
-          interim_path = "#{File.dirname(path)}/interim/#{File.basename(path)}"
+          interim_path = "#{File.dirname(path)}/interim/#{File.basename(path, File.extname(path))}.mp4"
           @movie.interim_paths << interim_path
         end
       else
@@ -82,7 +82,7 @@ module FFMPEG
 
       # Convert the individual videos into a common format, using the first video in as the "resolution"
       @movie.paths.each_with_index do |path, index|
-        command = "#{@movie.ffmpeg_command} -y -i #{path} -r #{output_frame_rate} -filter_complex \"[0:v]scale=#{@movie.height}:#{@movie.width},setsar=1[Scaled]\" -map \"[Scaled]\" -map \"0:a\" #{@movie.interim_paths[index]}"
+        command = "#{@movie.ffmpeg_command} -y -i #{path} -movflags faststart -r #{output_frame_rate} -filter_complex \"[0:v]scale=#{@movie.height}:#{@movie.width},setsar=1[Scaled]\" -map \"[Scaled]\" -map \"0:a\" #{@movie.interim_paths[index]}"
 
         FFMPEG.logger.info("Running transcoding...\n#{@command}\n")
         output = ""

--- a/lib/ffmpeg/transcoder.rb
+++ b/lib/ffmpeg/transcoder.rb
@@ -19,11 +19,11 @@ module FFMPEG
 
       if options.is_a?(String)
         prefix_options = convert_prefix_options_to_string(transcoder_prefix_options)
-        @raw_options = "#{prefix_options}-i #{@movie.path} #{options}"
+        @raw_options = "#{prefix_options} #{EncodingOptions.new.send(:convert_inputs, @movie.paths)} #{options}"
       elsif options.is_a?(EncodingOptions)
-        @raw_options = options.merge(:inputs => [@movie.path]) unless options.include? :inputs
+        @raw_options = options.merge(:inputs => @movie.paths) unless options.include? :inputs
       elsif options.is_a?(Hash)
-        @raw_options = EncodingOptions.new(options.merge(:inputs => [@movie.path]), transcoder_prefix_options)
+        @raw_options = EncodingOptions.new(options.merge(:inputs => @movie.paths), transcoder_prefix_options)
       else
         raise ArgumentError, "Unknown options format '#{options.class}', should be either EncodingOptions, Hash or String."
       end

--- a/lib/ffmpeg/transcoder.rb
+++ b/lib/ffmpeg/transcoder.rb
@@ -84,7 +84,7 @@ module FFMPEG
       @movie.paths.each_with_index do |path, index|
         command = "#{@movie.ffmpeg_command} -y -i #{path} -movflags faststart -r #{output_frame_rate} -filter_complex \"[0:v]scale=#{@movie.height}:#{@movie.width},setsar=1[Scaled]\" -map \"[Scaled]\" -map \"0:a\" #{@movie.interim_paths[index]}"
 
-        FFMPEG.logger.info("Running transcoding...\n#{@command}\n")
+        FFMPEG.logger.info("Running transcoding...\n#{command}\n")
         output = ""
 
         Open3.popen3(command) do |stdin, stdout, stderr, wait_thr|

--- a/lib/ffmpeg/transcoder.rb
+++ b/lib/ffmpeg/transcoder.rb
@@ -1,5 +1,6 @@
 require 'open3'
 require 'shellwords'
+require 'fileutils'
 
 module FFMPEG
   class Transcoder
@@ -17,13 +18,28 @@ module FFMPEG
       @movie = movie
       @output_file = output_file
 
+      if @movie.paths.size > 1
+        @movie.paths.each do |path|
+          # Make the interim path folder if it doesn't exist
+          dirname = "#{File.dirname(path)}/interim"
+          unless File.directory?(dirname)
+            FileUtils.mkdir_p(dirname)
+          end
+
+          interim_path = "#{File.dirname(path)}/interim/#{File.basename(path)}"
+          @movie.interim_paths << interim_path
+        end
+      else
+        @movie.interim_paths << @movie.paths
+      end
+
       if options.is_a?(String)
         prefix_options = convert_prefix_options_to_string(transcoder_prefix_options)
-        @raw_options = "#{prefix_options} #{EncodingOptions.new.convert_inputs(@movie.paths)} #{options}"
+        @raw_options = "#{prefix_options} #{EncodingOptions.new.convert_inputs(@movie.interim_paths)} #{options}"
       elsif options.is_a?(EncodingOptions)
-        @raw_options = options.merge(:inputs => @movie.paths) unless options.include? :inputs
+        @raw_options = options.merge(:inputs => @movie.interim_paths) unless options.include? :inputs
       elsif options.is_a?(Hash)
-        @raw_options = EncodingOptions.new(options.merge(:inputs => @movie.paths), transcoder_prefix_options)
+        @raw_options = EncodingOptions.new(options.merge(:inputs => @movie.interim_paths), transcoder_prefix_options)
       else
         raise ArgumentError, "Unknown options format '#{options.class}', should be either EncodingOptions, Hash or String."
       end
@@ -56,8 +72,56 @@ module FFMPEG
     end
 
     private
+    def pre_encode_if_necessary
+      # Don't pre-encode single inputs since it doesn't need any size conversion
+      return if @movie.interim_paths.size <= 1
+
+      # Set a minimum frame rate
+      output_frame_rate = [@raw_options[:frame_rate] || @movie.frame_rate, 30].max
+      output_frame_rate = 30 if output_frame_rate > 300
+
+      # Convert the individual videos into a common format, using the first video in as the "resolution"
+      @movie.paths.each_with_index do |path, index|
+        command = "#{@movie.ffmpeg_command} -y -i #{path} -r #{output_frame_rate} -filter_complex \"[0:v]scale=#{@movie.height}:#{@movie.width},setsar=1[Scaled]\" -map \"[Scaled]\" -map \"0:a\" #{@movie.interim_paths[index]}"
+
+        FFMPEG.logger.info("Running transcoding...\n#{@command}\n")
+        output = ""
+
+        Open3.popen3(command) do |stdin, stdout, stderr, wait_thr|
+          begin
+            yield(0.0) if block_given?
+            next_line = Proc.new do |line|
+              fix_encoding(line)
+              output << line
+              # if line.include?("time=")
+              #   if line =~ /time=(\d+):(\d+):(\d+.\d+)/ # ffmpeg 0.8 and above style
+              #     time = ($1.to_i * 3600) + ($2.to_i * 60) + $3.to_f
+              #   else # better make sure it wont blow up in case of unexpected output
+              #     time = 0.0
+              #   end
+              #   progress = time / @movie.duration
+              #   yield(progress) if block_given?
+              # end
+            end
+
+            if @@timeout
+              stderr.each_with_timeout(wait_thr.pid, @@timeout, 'size=', &next_line)
+            else
+              stderr.each('size=', &next_line)
+            end
+
+          rescue Timeout::Error
+            FFMPEG.logger.error "Process hung...\n@command\n#{command}\nOutput\n#{output}\n"
+            raise Error, "Process hung. Full output: #{output}"
+          end
+        end
+      end
+    end
+
     # frame= 4855 fps= 46 q=31.0 size=   45306kB time=00:02:42.28 bitrate=2287.0kbits/
     def transcode_movie
+      pre_encode_if_necessary
+
       @command = "#{@movie.ffmpeg_command} -y #{@raw_options} #{Shellwords.escape(@output_file)}"
 
       FFMPEG.logger.info("Running transcoding...\n#{@command}\n")
@@ -86,7 +150,7 @@ module FFMPEG
             stderr.each('size=', &next_line)
           end
 
-        rescue Timeout::Error => e
+        rescue Timeout::Error
           FFMPEG.logger.error "Process hung...\n@command\n#{@command}\nOutput\n#{@output}\n"
           raise Error, "Process hung. Full output: #{@output}"
         end

--- a/lib/ffmpeg/transcoder.rb
+++ b/lib/ffmpeg/transcoder.rb
@@ -19,7 +19,7 @@ module FFMPEG
 
       if options.is_a?(String)
         prefix_options = convert_prefix_options_to_string(transcoder_prefix_options)
-        @raw_options = "#{prefix_options} #{EncodingOptions.new.send(:convert_inputs, @movie.paths)} #{options}"
+        @raw_options = "#{prefix_options} #{EncodingOptions.new.convert_inputs(@movie.paths)} #{options}"
       elsif options.is_a?(EncodingOptions)
         @raw_options = options.merge(:inputs => @movie.paths) unless options.include? :inputs
       elsif options.is_a?(Hash)

--- a/lib/ffmpeg/transcoder.rb
+++ b/lib/ffmpeg/transcoder.rb
@@ -19,11 +19,11 @@ module FFMPEG
 
       if options.is_a?(String)
         prefix_options = convert_prefix_options_to_string(transcoder_prefix_options)
-        @raw_options = "#{prefix_options}-i #{Shellwords.escape(@movie.path)} #{options}"
+        @raw_options = "#{prefix_options}-i #{@movie.path} #{options}"
       elsif options.is_a?(EncodingOptions)
-        @raw_options = options.merge(:input => @movie.path) unless options.include? :input
+        @raw_options = options.merge(:inputs => [@movie.path]) unless options.include? :inputs
       elsif options.is_a?(Hash)
-        @raw_options = EncodingOptions.new(options.merge(:input => @movie.path), transcoder_prefix_options)
+        @raw_options = EncodingOptions.new(options.merge(:inputs => [@movie.path]), transcoder_prefix_options)
       else
         raise ArgumentError, "Unknown options format '#{options.class}', should be either EncodingOptions, Hash or String."
       end
@@ -96,7 +96,7 @@ module FFMPEG
     def validate_output_file(&block)
       if encoding_succeeded?
         yield(1.0) if block_given?
-        FFMPEG.logger.info "Transcoding of #{@movie.path} to #{@output_file} succeeded\n"
+        FFMPEG.logger.info "Transcoding of #{@movie.paths.join(', ')} to #{@output_file} succeeded\n"
       else
         errors = "Errors: #{@errors.join(", ")}. "
         FFMPEG.logger.error "Failed encoding...\n#{@command}\n\n#{@output}\n#{errors}\n"

--- a/lib/ffmpeg/transcoder.rb
+++ b/lib/ffmpeg/transcoder.rb
@@ -96,6 +96,7 @@ module FFMPEG
             next_line = Proc.new do |line|
               fix_encoding(line)
               output << line
+              # TODO: Update this to actually yield progress updates relative to the overall output
               # if line.include?("time=")
               #   if line =~ /time=(\d+):(\d+):(\d+.\d+)/ # ffmpeg 0.8 and above style
               #     time = ($1.to_i * 3600) + ($2.to_i * 60) + $3.to_f
@@ -121,7 +122,6 @@ module FFMPEG
       end
     end
 
-    # frame= 4855 fps= 46 q=31.0 size=   45306kB time=00:02:42.28 bitrate=2287.0kbits/
     def transcode_movie
       pre_encode_if_necessary
 

--- a/spec/ffmpeg/movie_spec.rb
+++ b/spec/ffmpeg/movie_spec.rb
@@ -240,18 +240,36 @@ module FFMPEG
           @movie = Movie.new("#{fixture_path}/movies/awesome movie.mov")
         end
 
-        it "should remember the movie path" do
-          expect(@movie.path).to eq("#{fixture_path}/movies/awesome\\ movie.mov")
-        end
+        context "escaped paths" do
+          it "should remember the movie path" do
+            expect(@movie.path).to eq("#{fixture_path}/movies/awesome\\ movie.mov")
+          end
 
-        it "should return first path if multiple" do
-          @movie = Movie.new(["#{fixture_path}/movies/awesome movie.mov", "#{fixture_path}/movies/awesome_widescreen.mov"])
-          expect(@movie.path).to eq("#{fixture_path}/movies/awesome\\ movie.mov")
-        end
+          it "should return first path if multiple" do
+            @movie = Movie.new(["#{fixture_path}/movies/awesome movie.mov", "#{fixture_path}/movies/awesome_widescreen.mov"])
+            expect(@movie.path).to eq("#{fixture_path}/movies/awesome\\ movie.mov")
+          end
 
-        it "should return all paths if multiple" do
-          @movie = Movie.new(["#{fixture_path}/movies/awesome movie.mov", "#{fixture_path}/movies/awesome_widescreen.mov"])
-          expect(@movie.paths).to eq(["#{fixture_path}/movies/awesome\\ movie.mov", "#{fixture_path}/movies/awesome_widescreen.mov"])
+          it "should return all paths if multiple" do
+            @movie = Movie.new(["#{fixture_path}/movies/awesome movie.mov", "#{fixture_path}/movies/awesome_widescreen.mov"])
+            expect(@movie.paths).to eq(["#{fixture_path}/movies/awesome\\ movie.mov", "#{fixture_path}/movies/awesome_widescreen.mov"])
+          end
+        end
+        context "unescaped paths" do
+
+          it "should remember the movie path" do
+            expect(@movie.unescaped_path).to eq("#{fixture_path}/movies/awesome movie.mov")
+          end
+
+          it "should return first path if multiple" do
+            @movie = Movie.new(["#{fixture_path}/movies/awesome movie.mov", "#{fixture_path}/movies/awesome_widescreen.mov"])
+            expect(@movie.unescaped_path).to eq("#{fixture_path}/movies/awesome movie.mov")
+          end
+
+          it "should return all paths if multiple" do
+            @movie = Movie.new(["#{fixture_path}/movies/awesome movie.mov", "#{fixture_path}/movies/awesome_widescreen.mov"])
+            expect(@movie.unescaped_paths).to eq(["#{fixture_path}/movies/awesome movie.mov", "#{fixture_path}/movies/awesome_widescreen.mov"])
+          end
         end
 
         it "should parse duration to number of seconds" do

--- a/spec/ffmpeg/movie_spec.rb
+++ b/spec/ffmpeg/movie_spec.rb
@@ -241,7 +241,17 @@ module FFMPEG
         end
 
         it "should remember the movie path" do
-          expect(@movie.path).to eq("#{fixture_path}/movies/awesome movie.mov")
+          expect(@movie.path).to eq("#{fixture_path}/movies/awesome\\ movie.mov")
+        end
+
+        it "should return first path if multiple" do
+          @movie = Movie.new(["#{fixture_path}/movies/awesome movie.mov", "#{fixture_path}/movies/awesome_widescreen.mov"])
+          expect(@movie.path).to eq("#{fixture_path}/movies/awesome\\ movie.mov")
+        end
+
+        it "should return all paths if multiple" do
+          @movie = Movie.new(["#{fixture_path}/movies/awesome movie.mov", "#{fixture_path}/movies/awesome_widescreen.mov"])
+          expect(@movie.paths).to eq(["#{fixture_path}/movies/awesome\\ movie.mov", "#{fixture_path}/movies/awesome_widescreen.mov"])
         end
 
         it "should parse duration to number of seconds" do

--- a/spec/ffmpeg/movie_spec.rb
+++ b/spec/ffmpeg/movie_spec.rb
@@ -408,8 +408,20 @@ module FFMPEG
     end
 
     describe "transcode" do
-      it "should run the transcoder" do
+      it "should run the transcoder for a single input" do
         movie = Movie.new("#{fixture_path}/movies/awesome movie.mov")
+
+        transcoder_double = double(Transcoder)
+        expect(Transcoder).to receive(:new).
+          with(movie, "#{tmp_path}/awesome.flv", {custom: "-vcodec libx264"}, {preserve_aspect_ratio: :width}, {}).
+          and_return(transcoder_double)
+        expect(transcoder_double).to receive(:run)
+
+        movie.transcode("#{tmp_path}/awesome.flv", {custom: "-vcodec libx264"}, {preserve_aspect_ratio: :width})
+      end
+
+      it "should run the transcoder for multiple inputs" do
+        movie = Movie.new(["#{fixture_path}/movies/awesome movie.mov", "#{fixture_path}/movies/awesome_widescreen.mov"])
 
         transcoder_double = double(Transcoder)
         expect(Transcoder).to receive(:new).
@@ -433,7 +445,7 @@ module FFMPEG
         probe_size = 1000000
 
         allow(File).to receive(:exist?).and_return(true)
-        movie = FFMPEG::Movie.new("", analyzeduration = analyzeduration, probesize = probesize)
+        movie = FFMPEG::Movie.new("", analyzeduration = analyze_duration, probesize = probe_size)
         expect(movie.ffprobe_command).to eq("#{FFMPEG.ffprobe_binary} -hide_banner -analyzeduration #{analyzeduration} -probesize #{probesize}")
       end
 


### PR DESCRIPTION
![](https://media3.giphy.com/media/l0HlJ7aAQyvjxM6B2/giphy.gif)

## Description
This is the initial implementation of multi-input support.
This performs a full re-encode when concatenating the videos, which bypasses the need for very strict checking / specific codec, resolution, and format matching.

When multiple inputs are included, only the first provided will be used for Movie content/details.

This implements [CRAP-349](https://vidyard.atlassian.net/browse/CRAP-349)

## Notes
There's a chance I've missed some other things here, please voice any concerns.

This has been tested in practice via Alchemist.

## Testing
All tests are passing:
![image](https://github.com/Vidyard/rlovelett-ffmpeg/assets/7606153/079540f0-d553-4918-affd-e176bf1da5cf)


[CRAP-349]: https://vidyard.atlassian.net/browse/CRAP-349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ