### PR TITLE
[CRT-414] Correct Multi-input Detection

### DIFF
--- a/lib/ffmpeg/encoding_options.rb
+++ b/lib/ffmpeg/encoding_options.rb
@@ -19,7 +19,7 @@ module FFMPEG
 
       # codecs should go before the presets so that the files will be matched successfully
       # all other parameters go after so that we can override whatever is in the preset
-      inputs                    = params.select { |p| p =~ /\-i / }
+      inputs                    = params.select { |p| p =~ /(^\-i| \-i) / }
       seek                      = params.select {|p| p =~ /\-ss/ }
       codecs                    = params.select { |p| p =~ /codec/ }
       presets                   = params.select { |p| p =~ /\-.pre/ }
@@ -28,7 +28,7 @@ module FFMPEG
       other   = params - codecs - presets - inputs - seek
       params  = prefix_params + seek + inputs + codecs + presets + other
 
-      num_inputs = inputs.first&.scan(/(?=\-i)/)&.count || 0
+      num_inputs = inputs.first&.scan(/(^\-i| \-i) /)&.count || 0
       if num_inputs > 1 && !contains_complex_filter
         multi_input_output_filter = "-filter_complex \"#{default_multi_input_complex_filter(num_inputs)}\" -map \"[v]\" -map \"[a]\""
         params.push(multi_input_output_filter)

--- a/spec/ffmpeg/encoding_options_spec.rb
+++ b/spec/ffmpeg/encoding_options_spec.rb
@@ -137,9 +137,15 @@ module FFMPEG
         expect(converted).to eq("-i somefile.mp4 -pass 1 passlogfile bla-i-bla")
       end
 
-      it "correctly estimates the number of inputs if `-i` exists elsewhere" do
+      it "correctly estimates the number of inputs if `-i` exists elsewhere for single input" do
         converted = EncodingOptions.new({ input: '/somefile/_d_nI-iSsSF9NkHEELjolg/input_7dbaa2c6c3eef5aecac7e5.mp4' }).to_s
         expect(converted).not_to include("-filter_complex")
+      end
+
+      it "correctly estimates the number of inputs if `-i` exists elsewhere for multiple inputs" do
+        converted = EncodingOptions.new({ inputs: ['/somefile/_d_nI-iSsSF9NkHEELjolg/input_7dbaa2c6c3eef5aecac7e51.mp4', '/somefile/_d_nI-iSsSF9NkHEELjolg/input_7dbaa2c6c3eef5aecac7e52.mp4'] }).to_s
+        expect(converted).to include("-filter_complex")
+        expect(converted).to include("concat=n=2:v=1:a=1")
       end
 
       it "correctly detects multiple inputs if three provided" do

--- a/spec/ffmpeg/encoding_options_spec.rb
+++ b/spec/ffmpeg/encoding_options_spec.rb
@@ -137,6 +137,17 @@ module FFMPEG
         expect(converted).to eq("-i somefile.mp4 -pass 1 passlogfile bla-i-bla")
       end
 
+      it "correctly estimates the number of inputs if `-i` exists elsewhere" do
+        converted = EncodingOptions.new({ input: '/somefile/_d_nI-iSsSF9NkHEELjolg/input_7dbaa2c6c3eef5aecac7e5.mp4' }).to_s
+        expect(converted).not_to include("-filter_complex")
+      end
+
+      it "correctly detects multiple inputs if three provided" do
+        converted = EncodingOptions.new({ inputs: ['somefile.mp4', 'someotherfile.mp4', 'someotherotherfile.mp4'] }).to_s
+        expect(converted).to include("-filter_complex")
+        expect(converted).to include("concat=n=3:v=1:a=1")
+      end
+
       it "should convert a lot of them simultaneously" do
         converted = EncodingOptions.new(video_codec: "libx264", audio_codec: "aac", video_bitrate: "1000k").to_s
         expect(converted).to match(/-acodec aac/)


### PR DESCRIPTION
![](https://media3.giphy.com/media/3o6MbqLCdm4VuhIKl2/giphy.gif)

## Description
The multi-input detection is looking for instances of `-i`, and is not being specific enough to look for instances of `-i ` (at the start of the line) or ` -i ` (anywhere in the line). This updates that.


Example line of misdetection:
```bash
/usr/local/bin/ffmpeg -hide_banner -analyzeduration 15000000 -probesize 15000000 -y -i /vidyard/Alchemist/tmp/development/_d_nI-iSsSF9NkHEELjolg/input_7dbaa2c6c3eef5aecac7e5.mp4 -vcodec h264_nvenc -acodec libfdk_aac -ar 0 -threads 1 -s 640x360  -max_muxing_queue_size 1024 -movflags faststart -color_primaries 1 -colorspace 1 -color_trc 1 -loglevel warning -preset p7 -tune hq -rc-lookahead 32 -b:a 0k -ac 0 -g 47 -b:v 300k -filter_complex "[0:v]setpts=PTS-STARTPTS[v0];[1:v]setpts=PTS-STARTPTS[v1];[v0][0:a][v1][1:a]concat=n=2:v=1:a=1[v][a]" -map "[v]" -map "[a]" -aspect 1.7777777777777777 /local/development/AlchemistOutput_37/output_e7bdb8b15fb3fcd645b0d0.mp4
```
This line should only be detected as having a single input, but because of two occurrences of -i, even though one is part of a different string, it’s causing this to create an invalid filtergraph which then errors upon execution.