### PR TITLE
[CRT-803] Avoid Race Condition For Multiple Inputs, Update Logging

### DIFF
--- a/lib/ffmpeg/transcoder.rb
+++ b/lib/ffmpeg/transcoder.rb
@@ -1,6 +1,7 @@
 require 'open3'
 require 'shellwords'
 require 'fileutils'
+require 'securerandom'
 
 module FFMPEG
   class Transcoder
@@ -26,7 +27,7 @@ module FFMPEG
             FileUtils.mkdir_p(dirname)
           end
 
-          interim_path = "#{File.dirname(path)}/interim/#{File.basename(path, File.extname(path))}.mp4"
+          interim_path = "#{File.dirname(path)}/interim/#{File.basename(path, File.extname(path))}_#{SecureRandom.urlsafe_base64}.mp4"
           @movie.interim_paths << interim_path
         end
       else
@@ -87,7 +88,7 @@ module FFMPEG
       @movie.paths.each_with_index do |path, index|
         command = "#{@movie.ffmpeg_command} -y -i #{path} -movflags faststart #{pre_encode_options} -r #{output_frame_rate} -filter_complex \"[0:v]scale=#{@movie.height}:#{@movie.width},setsar=1[Scaled]\" -map \"[Scaled]\" -map \"0:a\" #{@movie.interim_paths[index]}"
 
-        FFMPEG.logger.info("Running transcoding...\n#{command}\n")
+        FFMPEG.logger.info("Running pre-encoding...\n#{command}\n")
         output = ""
 
         Open3.popen3(command) do |stdin, stdout, stderr, wait_thr|


### PR DESCRIPTION
![](https://media1.giphy.com/media/6Z3D5t31ZdoNW/giphy.gif)

## Description
With the current implementation, if the same inputs are re-used for an output, there will be collisions and race conditions will happen relating to the processing of the interim inputs.

This "fixes" [CRT-803](https://vidyard.atlassian.net/browse/CRT-803), though I will continue investigating after since this method leaves a lot of waste.

[CRT-803]: https://vidyard.atlassian.net/browse/CRT-803?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ