### PR TITLE
[CRT-905] Stitching | Pad Non-Audio Inputs If Any Input Contains Audio

### DIFF
--- a/lib/ffmpeg/encoding_options.rb
+++ b/lib/ffmpeg/encoding_options.rb
@@ -4,8 +4,8 @@ module FFMPEG
   class EncodingOptions < Hash
     def initialize(options = {}, prefix_options = {})
       @prefix_options = prefix_options
-      # If we are not told otherwise, assume that all streams contain audio
-      @all_streams_contain_audio = options.fetch(:all_streams_contain_audio, true)
+      # If we are not told otherwise, assume that at least one stream contains audio
+      @any_streams_contain_audio = options.fetch(:any_streams_contain_audio, true)
       merge!(options)
     end
 
@@ -33,7 +33,7 @@ module FFMPEG
       num_inputs = inputs.first&.scan(/(^\-i| \-i) /)&.count || 0
       if num_inputs > 1 && !contains_complex_filter
         multi_input_output_filter = "-filter_complex \"#{default_multi_input_complex_filter(num_inputs)}\" -map \"[v]\""
-        multi_input_output_filter += " -map \"[a]\"" if @all_streams_contain_audio
+        multi_input_output_filter += " -map \"[a]\"" if @any_streams_contain_audio
         params.push(multi_input_output_filter)
       end
 
@@ -75,11 +75,11 @@ module FFMPEG
         input_forming += "[#{index}:v]setpts=PTS-STARTPTS[v#{index}];"
         # TODO support audio-less videos by checking if any streams exist
         final_grouping += "[v#{index}]"
-        final_grouping += "[#{index}:a]" if @all_streams_contain_audio
+        final_grouping += "[#{index}:a]" if @any_streams_contain_audio
       end
 
-      final_grouping += "concat=n=#{num_inputs}:v=1:a=#{@all_streams_contain_audio ? 1 : 0}[v]"
-      final_grouping += "[a]" if @all_streams_contain_audio
+      final_grouping += "concat=n=#{num_inputs}:v=1:a=#{@any_streams_contain_audio ? 1 : 0}[v]"
+      final_grouping += "[a]" if @any_streams_contain_audio
       return "#{input_forming}#{final_grouping}"
     end
 

--- a/lib/ffmpeg/movie.rb
+++ b/lib/ffmpeg/movie.rb
@@ -239,20 +239,20 @@ module FFMPEG
       BlackDetect.new(self).run
     end
 
-    def all_streams_contain_audio?
-      @all_streams_contain_audio ||= calc_all_streams_contain_audio
+    def any_streams_contain_audio?
+      @any_streams_contain_audio ||= calc_any_streams_contain_audio
     end
 
     protected
 
-    def calc_all_streams_contain_audio
-      return false if @audio_stream.nil? || @audio_stream.empty?
+    def calc_any_streams_contain_audio
+      return true unless @audio_stream.nil? || @audio_stream.empty?
       @unescaped_paths.each do |path|
         local_movie = Movie.new(path)
-        return false if local_movie.audio_stream.nil? || local_movie.audio_stream.empty?
+        return true unless local_movie.audio_stream.nil? || local_movie.audio_stream.empty?
       end
 
-      return true
+      return false
     end
 
     def aspect_from_dar

--- a/lib/ffmpeg/transcoder.rb
+++ b/lib/ffmpeg/transcoder.rb
@@ -100,8 +100,6 @@ module FFMPEG
         FFMPEG.logger.info("Running pre-encoding...\n#{command}\n")
         output = ""
 
-        puts command
-
         Open3.popen3(command) do |stdin, stdout, stderr, wait_thr|
           begin
             yield(0.0) if block_given?

--- a/spec/ffmpeg/encoding_options_spec.rb
+++ b/spec/ffmpeg/encoding_options_spec.rb
@@ -156,13 +156,13 @@ module FFMPEG
         end
 
         it "with audio override true" do
-          converted = EncodingOptions.new({ inputs: ['somefile.mp4', 'someotherfile.mp4', 'someotherotherfile.mp4'], all_streams_contain_audio: true }).to_s
+          converted = EncodingOptions.new({ inputs: ['somefile.mp4', 'someotherfile.mp4', 'someotherotherfile.mp4'], any_streams_contain_audio: true }).to_s
           expect(converted).to include("-filter_complex")
           expect(converted).to include("concat=n=3:v=1:a=1")
         end
 
         it "with audio override false" do
-          converted = EncodingOptions.new({ inputs: ['somefile.mp4', 'someotherfile.mp4', 'someotherotherfile.mp4'], all_streams_contain_audio: false }).to_s
+          converted = EncodingOptions.new({ inputs: ['somefile.mp4', 'someotherfile.mp4', 'someotherotherfile.mp4'], any_streams_contain_audio: false }).to_s
           expect(converted).to include("-filter_complex")
           expect(converted).to include("concat=n=3:v=1:a=0")
         end

--- a/spec/ffmpeg/movie_spec.rb
+++ b/spec/ffmpeg/movie_spec.rb
@@ -425,27 +425,27 @@ module FFMPEG
       end
     end
 
-    describe '#all_streams_contain_audio?' do
+    describe '#any_streams_contain_audio?' do
       it 'caches the result' do
-        expect_any_instance_of(Movie).to receive(:calc_all_streams_contain_audio).once.and_return(true)
+        expect_any_instance_of(Movie).to receive(:calc_any_streams_contain_audio).once.and_return(true)
         movie = Movie.new("#{fixture_path}/movies/test_automation_5s.mp4")
-        expect(movie.all_streams_contain_audio?).to be_truthy
-        expect(movie.all_streams_contain_audio?).to be_truthy
+        expect(movie.any_streams_contain_audio?).to be_truthy
+        expect(movie.any_streams_contain_audio?).to be_truthy
       end
 
       it 'returns true if one stream contains audio' do
         movie = Movie.new("#{fixture_path}/movies/awesome_widescreen.mov")
-        expect(movie.all_streams_contain_audio?).to be_truthy
+        expect(movie.any_streams_contain_audio?).to be_truthy
       end
 
-      it 'returns true if all streams contain audio' do
-        movie = Movie.new(["#{fixture_path}/movies/awesome_widescreen.mov", "#{fixture_path}/movies/awesome_widescreen.mov"])
-        expect(movie.all_streams_contain_audio?).to be_truthy
-      end
-
-      it 'returns false if any stream contains no audio' do
+      it 'returns true if any streams contain audio' do
         movie = Movie.new(["#{fixture_path}/movies/test_automation_5s.mp4", "#{fixture_path}/movies/awesome_widescreen.mov"])
-        expect(movie.all_streams_contain_audio?).to be_falsey
+        expect(movie.any_streams_contain_audio?).to be_truthy
+      end
+
+      it 'returns false if all stream contains no audio' do
+        movie = Movie.new(["#{fixture_path}/movies/test_automation_5s.mp4", "#{fixture_path}/movies/test_automation_5s.mp4"])
+        expect(movie.any_streams_contain_audio?).to be_falsey
       end
 
     end


### PR DESCRIPTION
![](https://media4.giphy.com/media/l2Je7bPpjKbGJqSUo/giphy.gif)

## Description

After discussing with the larger team, it makes more sense to fill the resulting video with silence when at least one input contains audio, rather than outright stripping it if all input videos did not contain audio.

Likely addresses [CRT-905](https://vidyard.atlassian.net/browse/CRT-905)

[CRT-905]: https://vidyard.atlassian.net/browse/CRT-905?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ