### PR TITLE
[CRT-1862] Add audio and video stream start time

### DIFF
--- a/lib/ffmpeg/movie.rb
+++ b/lib/ffmpeg/movie.rb
@@ -5,8 +5,8 @@ require 'posix-spawn'
 module FFMPEG
   class Movie
     attr_reader :path, :paths, :unescaped_paths, :interim_paths, :duration, :time, :bitrate, :rotation, :creation_time, :analyzeduration, :probesize
-    attr_reader :video_stream, :video_codec, :video_bitrate, :colorspace, :width, :height, :sar, :dar, :frame_rate, :has_b_frames, :video_profile, :video_level
-    attr_reader :audio_streams, :audio_stream, :audio_codec, :audio_bitrate, :audio_sample_rate, :audio_channels, :audio_tags
+    attr_reader :video_stream, :video_codec, :video_bitrate, :colorspace, :width, :height, :sar, :dar, :frame_rate, :video_start_time, :has_b_frames, :video_profile, :video_level
+    attr_reader :audio_streams, :audio_stream, :audio_codec, :audio_bitrate, :audio_sample_rate, :audio_channels, :audio_tags, :audio_start_time
     attr_reader :color_primaries, :avframe_color_space, :color_transfer
     attr_reader :container
     attr_reader :error
@@ -89,12 +89,12 @@ module FFMPEG
           @has_b_frames = video_stream[:has_b_frames].to_i
           @video_profile = video_stream[:profile]
           @video_level = video_stream[:level] / 10.0 unless video_stream[:level].nil?
-
           @frame_rate = unless video_stream[:avg_frame_rate] == '0/0'
                           Rational(video_stream[:avg_frame_rate])
                         else
                           nil
                         end
+          @video_start_time = video_stream[:start_time].to_f
 
           @video_stream = "#{video_stream[:codec_name]} (#{video_stream[:profile]}) (#{video_stream[:codec_tag_string]} / #{video_stream[:codec_tag]}), #{colorspace}, #{resolution} [SAR #{sar} DAR #{dar}]"
 
@@ -129,6 +129,7 @@ module FFMPEG
           @audio_channel_layout = audio_stream[:channel_layout]
           @audio_tags = audio_stream[:tags]
           @audio_stream = audio_stream[:overview]
+          @audio_start_time = audio_stream[:start_time].to_f
         end
       end
 

--- a/lib/ffmpeg/movie.rb
+++ b/lib/ffmpeg/movie.rb
@@ -5,7 +5,7 @@ require 'posix-spawn'
 module FFMPEG
   class Movie
     attr_reader :path, :paths, :unescaped_paths, :interim_paths, :duration, :time, :bitrate, :rotation, :creation_time, :analyzeduration, :probesize
-    attr_reader :video_stream, :video_codec, :video_bitrate, :colorspace, :width, :height, :sar, :dar, :frame_rate, :video_start_time, :has_b_frames, :video_profile, :video_level
+    attr_reader :video_stream, :video_codec, :video_bitrate, :colorspace, :width, :height, :sar, :dar, :frame_rate, :has_b_frames, :video_profile, :video_level, :video_start_time
     attr_reader :audio_streams, :audio_stream, :audio_codec, :audio_bitrate, :audio_sample_rate, :audio_channels, :audio_tags, :audio_start_time
     attr_reader :color_primaries, :avframe_color_space, :color_transfer
     attr_reader :container


### PR DESCRIPTION
![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExODY5bGhtZzh6aGF3cW11NG90YjdxOXE0dXlndGVtcTdmdDJpbzFjOSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/9u514UZd57mRhnBCEk/giphy.gif)

This adds the video and audio streams' `start_time` to the metadata.

### Testing
After adding them in Alchemist, I could see the metadata in the input database.
![image](https://github.com/user-attachments/assets/19a701ee-c536-40a7-aea7-b526598318dc)
