### PR TITLE
[CRT-272] Log std_error With Ffprobe Parsing Failures As Well

### DIFF
--- a/lib/ffmpeg/movie.rb
+++ b/lib/ffmpeg/movie.rb
@@ -48,7 +48,7 @@ module FFMPEG
       begin
         metadata = MultiJson.load(std_output, symbolize_keys: true)
       rescue MultiJson::ParseError
-        raise "Could not parse output from FFProbe:\n#{ std_output }"
+        raise "Could not parse output from FFProbe:\n#{ std_output }\n#{ std_error }"
       end
 
       if metadata.key?(:error)


### PR DESCRIPTION
![](https://media1.giphy.com/media/3o6Zt6ML6BklcajjsA/giphy.gif)

## Description
Occasionally we see parsing failures from the output, and while sometimes it's related to the output being truncated, sometimes there is no output to std_output at all and we need to see std_error for why this happened.