### PR TITLE
[CRT-1953] Support Pre-encode for videos that have dynamic frame resolutions

### DIFF
--- a/lib/ffmpeg/movie.rb
+++ b/lib/ffmpeg/movie.rb
@@ -10,7 +10,8 @@ module FFMPEG
     attr_reader :color_primaries, :avframe_color_space, :color_transfer
     attr_reader :container
     attr_reader :error
-    attr_reader :should_pre_encode
+
+    attr_accessor :should_pre_encode
 
     UNSUPPORTED_CODEC_PATTERN = /^Unsupported codec with id (\d+) for input stream (\d+)$/
 
@@ -264,6 +265,10 @@ module FFMPEG
 
     def any_streams_contain_audio?
       @any_streams_contain_audio ||= calc_any_streams_contain_audio
+    end
+
+    def did_pre_encode?
+      @should_pre_encode ||= false
     end
 
     protected

--- a/lib/ffmpeg/movie.rb
+++ b/lib/ffmpeg/movie.rb
@@ -11,10 +11,7 @@ module FFMPEG
     attr_reader :container
     attr_reader :error
 
-    attr_reader :did_pre_encode
-    attr_reader :has_dynamic_resolution
-
-    attr_accessor :has_dynamic_resolution, :did_pre_encode
+    attr_accessor :has_dynamic_resolution, :did_pre_encode, :requires_pre_encode
 
     UNSUPPORTED_CODEC_PATTERN = /^Unsupported codec with id (\d+) for input stream (\d+)$/
 

--- a/lib/ffmpeg/movie.rb
+++ b/lib/ffmpeg/movie.rb
@@ -266,6 +266,7 @@ module FFMPEG
       @any_streams_contain_audio ||= calc_any_streams_contain_audio
     end
 
+    # Get the max width and max height of all frames in the input movies and check if the resolutions of frames are consistent
     def check_frame_resolutions
       max_width = width
       max_height = height
@@ -275,12 +276,12 @@ module FFMPEG
       unescaped_paths.each do |path|
         local_movie = Movie.new(path) # reference from highest res frames
 
+        # this command should be fairly fast - ~30 seconds on a 3 hr video
         command = "#{ffprobe_command} -v error -select_streams v:0 -show_entries frame=width,height -of csv=p=0 -skip_frame nokey #{Shellwords.escape(local_movie.path)}" # -skip_frame nokey speeds up processing significantly
         FFMPEG.logger.info("Running check for varying resolution...\n#{command}\n")
 
         Open3.popen3(command) do |stdin, stdout, stderr, wait_thr|
           stdout.each_line do |line|
-            # Parse the width and height from the line
             frame_width, frame_height = line.split(',').map(&:to_i)
 
             # Update max width and max height

--- a/lib/ffmpeg/movie.rb
+++ b/lib/ffmpeg/movie.rb
@@ -268,8 +268,8 @@ module FFMPEG
     end
 
     def check_frame_resolutions
-      max_width = @movie.width
-      max_height = @movie.height
+      max_width = width
+      max_height = height
       differing_frame_resolutions = false
       last_line = nil
 

--- a/lib/ffmpeg/movie.rb
+++ b/lib/ffmpeg/movie.rb
@@ -11,7 +11,8 @@ module FFMPEG
     attr_reader :container
     attr_reader :error
 
-    attr_accessor :should_pre_encode
+    attr_reader :should_pre_encode
+    protected :should_pre_encode=
 
     UNSUPPORTED_CODEC_PATTERN = /^Unsupported codec with id (\d+) for input stream (\d+)$/
 

--- a/lib/ffmpeg/movie.rb
+++ b/lib/ffmpeg/movie.rb
@@ -14,6 +14,8 @@ module FFMPEG
     attr_reader :did_pre_encode
     attr_reader :has_dynamic_resolution
 
+    attr_accessor :has_dynamic_resolution, :did_pre_encode
+
     UNSUPPORTED_CODEC_PATTERN = /^Unsupported codec with id (\d+) for input stream (\d+)$/
 
     def initialize(paths, analyzeduration = 15000000, probesize=15000000 )
@@ -270,8 +272,6 @@ module FFMPEG
     end
 
     protected
-
-    attr_accessor :has_dynamic_resolution, :did_pre_encode
 
     # attr_writer :did_pre_encode
     # attr_writer :has_dynamic_resolution

--- a/lib/ffmpeg/movie.rb
+++ b/lib/ffmpeg/movie.rb
@@ -16,6 +16,7 @@ module FFMPEG
     UNSUPPORTED_CODEC_PATTERN = /^Unsupported codec with id (\d+) for input stream (\d+)$/
 
     @has_dynamic_resolution = false
+    @requires_pre_encode = nil
 
     def initialize(paths, analyzeduration = 15000000, probesize=15000000 )
       paths = [paths] unless paths.is_a? Array

--- a/lib/ffmpeg/movie.rb
+++ b/lib/ffmpeg/movie.rb
@@ -16,7 +16,6 @@ module FFMPEG
     UNSUPPORTED_CODEC_PATTERN = /^Unsupported codec with id (\d+) for input stream (\d+)$/
 
     @has_dynamic_resolution = false
-    @requires_pre_encode = false
 
     def initialize(paths, analyzeduration = 15000000, probesize=15000000 )
       paths = [paths] unless paths.is_a? Array

--- a/lib/ffmpeg/movie.rb
+++ b/lib/ffmpeg/movie.rb
@@ -277,9 +277,13 @@ module FFMPEG
       last_dimensions = nil
 
       unescaped_paths.each do |path|
-        local_movie = Movie.new(path) # reference from highest res frames
+        local_movie = Movie.new(path)
 
-        # this command should be fairly fast - ~30 seconds on a 3 hr video
+        # set max width and height from the movie metadata first
+        max_width = [max_width, local_movie.width].max
+        max_height = [max_height, local_movie.height].max
+
+        # Get each keyframe's resolution - this command should be fairly fast, ~30 seconds on a 3 hr video
         command = "#{ffprobe_command} -v error -select_streams v:0 -show_entries frame=width,height -of csv=p=0 -skip_frame nokey #{Shellwords.escape(local_movie.path)}" # -skip_frame nokey speeds up processing significantly, only evaluating key frames which seems to be sufficient for frame resolution checks
         FFMPEG.logger.info("Running check for varying resolution...\n#{command}\n")
 

--- a/lib/ffmpeg/movie.rb
+++ b/lib/ffmpeg/movie.rb
@@ -276,10 +276,10 @@ module FFMPEG
       differing_frame_resolutions = false
       last_line = nil
 
-      @movie.unescaped_paths.each do |path|
+      unescaped_paths.each do |path|
         local_movie = Movie.new(path) # reference from highest res frames
 
-        command = "#{@movie.ffprobe_command} -v error -select_streams v:0 -show_entries frame=width,height -of csv=p=0 -skip_frame nokey #{Shellwords.escape(local_movie.path)}" # -skip_frame nokey speeds up processing significantly
+        command = "#{ffprobe_command} -v error -select_streams v:0 -show_entries frame=width,height -of csv=p=0 -skip_frame nokey #{Shellwords.escape(local_movie.path)}" # -skip_frame nokey speeds up processing significantly
         FFMPEG.logger.info("Running check for varying resolution...\n#{command}\n")
 
         Open3.popen3(command) do |stdin, stdout, stderr, wait_thr|

--- a/lib/ffmpeg/movie.rb
+++ b/lib/ffmpeg/movie.rb
@@ -249,6 +249,7 @@ module FFMPEG
     end
 
     def transcode(output_file, options = EncodingOptions.new, transcoder_options = {}, transcoder_prefix_options = {}, &)
+      puts "\n\nRlovelett-ffmpeg: Movie.transcode\n\n"
       Transcoder.new(self, output_file, options, transcoder_options, transcoder_prefix_options).run(&)
     end
 

--- a/lib/ffmpeg/movie.rb
+++ b/lib/ffmpeg/movie.rb
@@ -271,8 +271,8 @@ module FFMPEG
 
     # Get the max width and max height of all frames in the input movies and check if the resolutions of frames are consistent
     def check_frame_resolutions
-      max_width = width
-      max_height = height
+      max_width = width || 0
+      max_height = height || 0
       differing_frame_resolutions = false
       last_dimensions = nil
 
@@ -291,6 +291,8 @@ module FFMPEG
           stdout.each_line do |line|
             frame_dimensions = line.split(',').first(2).map(&:to_i) # get the first two values as ffmpeg can sometimes provide an extra comma
             frame_width, frame_height = frame_dimensions
+
+            next if frame_width.nil? || frame_height.nil?
 
             # Update max width and max height
             max_width = [max_width, frame_width].max

--- a/lib/ffmpeg/movie.rb
+++ b/lib/ffmpeg/movie.rb
@@ -11,8 +11,8 @@ module FFMPEG
     attr_reader :container
     attr_reader :error
 
-    attr_reader :should_pre_encode
-    protected :should_pre_encode=
+    attr_reader :did_pre_encode
+    attr_reader :has_dynamic_resolution
 
     UNSUPPORTED_CODEC_PATTERN = /^Unsupported codec with id (\d+) for input stream (\d+)$/
 
@@ -30,6 +30,7 @@ module FFMPEG
       @interim_paths = []
       @analyzeduration = analyzeduration;
       @probesize = probesize;
+      @did_pre_encode = false
 
       if @paths.any? {|path| path.end_with?('.m3u8') }
         optional_arguments = '-allowed_extensions ALL'
@@ -268,11 +269,10 @@ module FFMPEG
       @any_streams_contain_audio ||= calc_any_streams_contain_audio
     end
 
-    def did_pre_encode?
-      @should_pre_encode ||= false
-    end
-
     protected
+
+    # attr_writer :did_pre_encode
+    # attr_writer :has_dynamic_resolution
 
     def calc_any_streams_contain_audio
       return true unless @audio_stream.nil? || @audio_stream.empty?

--- a/lib/ffmpeg/movie.rb
+++ b/lib/ffmpeg/movie.rb
@@ -291,6 +291,7 @@ module FFMPEG
 
             # Check if the current frame resolution differs from the last frame
             if last_dimensions && frame_dimensions != last_dimensions
+              puts "1111111Found differing frame resolutions: #{last_dimensions} vs #{frame_dimensions}"
               differing_frame_resolutions = true
             end
 

--- a/lib/ffmpeg/movie.rb
+++ b/lib/ffmpeg/movie.rb
@@ -10,6 +10,7 @@ module FFMPEG
     attr_reader :color_primaries, :avframe_color_space, :color_transfer
     attr_reader :container
     attr_reader :error
+    attr_reader :should_pre_encode
 
     UNSUPPORTED_CODEC_PATTERN = /^Unsupported codec with id (\d+) for input stream (\d+)$/
 

--- a/lib/ffmpeg/movie.rb
+++ b/lib/ffmpeg/movie.rb
@@ -271,6 +271,8 @@ module FFMPEG
 
     protected
 
+    attr_accessor :has_dynamic_resolution, :did_pre_encode
+
     # attr_writer :did_pre_encode
     # attr_writer :has_dynamic_resolution
 

--- a/lib/ffmpeg/movie.rb
+++ b/lib/ffmpeg/movie.rb
@@ -282,7 +282,7 @@ module FFMPEG
 
         Open3.popen3(command) do |stdin, stdout, stderr, wait_thr|
           stdout.each_line do |line|
-            frame_dimensions = line.split(',').reject(&:empty?).map(&:to_i)
+            frame_dimensions = line.split(',').first(2).map(&:to_i) # get the first two values as ffmpeg can sometimes provide an extra comma
             frame_width, frame_height = frame_dimensions
 
             # Update max width and max height

--- a/lib/ffmpeg/movie.rb
+++ b/lib/ffmpeg/movie.rb
@@ -287,7 +287,7 @@ module FFMPEG
         command = "#{ffprobe_command} -v error -select_streams v:0 -show_entries frame=width,height -of csv=p=0 -skip_frame nokey #{Shellwords.escape(local_movie.path)}" # -skip_frame nokey speeds up processing significantly, only evaluating key frames which seems to be sufficient for frame resolution checks
         FFMPEG.logger.info("Running check for varying resolution...\n#{command}\n")
 
-        Open3.popen3(command) do |stdin, stdout, stderr, wait_thr|
+        Open3.popen3(command) do |_stdin, stdout, _stderr, _wait_thr|
           stdout.each_line do |line|
             frame_dimensions = line.split(',').first(2).map(&:to_i) # get the first two values as ffmpeg can sometimes provide an extra comma
             frame_width, frame_height = frame_dimensions

--- a/lib/ffmpeg/movie.rb
+++ b/lib/ffmpeg/movie.rb
@@ -271,7 +271,7 @@ module FFMPEG
       max_width = width
       max_height = height
       differing_frame_resolutions = false
-      last_line = nil
+      last_dimensions = nil
 
       unescaped_paths.each do |path|
         local_movie = Movie.new(path) # reference from highest res frames
@@ -282,18 +282,19 @@ module FFMPEG
 
         Open3.popen3(command) do |stdin, stdout, stderr, wait_thr|
           stdout.each_line do |line|
-            frame_width, frame_height = line.split(',').map(&:to_i)
+            frame_dimensions = line.split(',').reject(&:empty?).map(&:to_i)
+            frame_width, frame_height = frame_dimensions
 
             # Update max width and max height
             max_width = [max_width, frame_width].max
             max_height = [max_height, frame_height].max
 
             # Check if the current frame resolution differs from the last frame
-            if last_line && line != last_line
+            if last_dimensions && frame_dimensions != last_dimensions
               differing_frame_resolutions = true
             end
 
-            last_line = line
+            last_dimensions = frame_dimensions
           end
         end
       end

--- a/lib/ffmpeg/movie.rb
+++ b/lib/ffmpeg/movie.rb
@@ -268,8 +268,11 @@ module FFMPEG
     end
 
     def check_frame_resolutions
+      puts '1'
       max_width = width
+      puts '2'
       max_height = height
+      puts '3'
       differing_frame_resolutions = false
       last_line = nil
 
@@ -282,11 +285,11 @@ module FFMPEG
         Open3.popen3(command) do |stdin, stdout, stderr, wait_thr|
           stdout.each_line do |line|
             # Parse the width and height from the line
-            width, height = line.split(',').map(&:to_i)
+            frame_width, frame_height = line.split(',').map(&:to_i)
 
             # Update max width and max height
-            max_width = [max_width, width].max
-            max_height = [max_height, height].max
+            max_width = [max_width, frame_width].max
+            max_height = [max_height, frame_height].max
 
             # Check if the current frame resolution differs from the last frame
             if last_line && line != last_line
@@ -298,6 +301,7 @@ module FFMPEG
         end
       end
 
+      puts '4'
       @has_dynamic_resolution = differing_frame_resolutions
 
       # Return the max width, max height, and whether differing resolutions were found

--- a/lib/ffmpeg/movie.rb
+++ b/lib/ffmpeg/movie.rb
@@ -251,7 +251,6 @@ module FFMPEG
     end
 
     def transcode(output_file, options = EncodingOptions.new, transcoder_options = {}, transcoder_prefix_options = {}, &)
-      puts "\n\nRlovelett-ffmpeg: Movie.transcode\n\n"
       Transcoder.new(self, output_file, options, transcoder_options, transcoder_prefix_options).run(&)
     end
 
@@ -268,11 +267,8 @@ module FFMPEG
     end
 
     def check_frame_resolutions
-      puts '1'
       max_width = width
-      puts '2'
       max_height = height
-      puts '3'
       differing_frame_resolutions = false
       last_line = nil
 
@@ -301,7 +297,6 @@ module FFMPEG
         end
       end
 
-      puts '4'
       @has_dynamic_resolution = differing_frame_resolutions
 
       # Return the max width, max height, and whether differing resolutions were found

--- a/lib/ffmpeg/transcoder.rb
+++ b/lib/ffmpeg/transcoder.rb
@@ -29,10 +29,11 @@ module FFMPEG
       @output_file = output_file
       @transcoder_options = transcoder_options
 
+      puts "\n\nTanscoder options: #{@transcoder_options}"
+      puts "should check frame resolutions: #{@transcoder_options[:permit_dynamic_resolution_pre_encode]}\n\n"
       # If the movie has varying resolutions, we need to pre-encode
       # This is because ffmpeg can't reliably handle inputs that contain frames with differing resolutions particularly for trimming with `filter_complex`
       check_frame_resolutions if @transcoder_options[:permit_dynamic_resolution_pre_encode]
-
       if requires_pre_encode
         @movie.paths.each do |path|
           # Make the interim path folder if it doesn't exist

--- a/lib/ffmpeg/transcoder.rb
+++ b/lib/ffmpeg/transcoder.rb
@@ -20,7 +20,8 @@ module FFMPEG
 
     def requires_pre_encode
       # Don't pre-encode single inputs since if pre_encode is false as they don't need any size conversion
-      @movie.paths.size > 1 || (@transcoder_options[:permit_dynamic_resolution_pre_encode] && @movie.has_dynamic_resolution)
+      @movie.requires_pre_encode = @movie.paths.size > 1 || (@transcoder_options[:permit_dynamic_resolution_pre_encode] && @movie.has_dynamic_resolution)
+      return @movie.requires_pre_encode
     end
 
     def initialize(movie, output_file, options = EncodingOptions.new, transcoder_options = {}, transcoder_prefix_options = {})

--- a/lib/ffmpeg/transcoder.rb
+++ b/lib/ffmpeg/transcoder.rb
@@ -25,13 +25,10 @@ module FFMPEG
     end
 
     def initialize(movie, output_file, options = EncodingOptions.new, transcoder_options = {}, transcoder_prefix_options = {})
-      puts "\n\nRlovelett::FFMPEG::Transcoder initialize\n\n"
       @movie = movie
       @output_file = output_file
       @transcoder_options = transcoder_options
 
-      puts "\n\nTanscoder options: #{@transcoder_options}"
-      puts "should check frame resolutions: #{@transcoder_options[:permit_dynamic_resolution_pre_encode]}\n\n"
       # If the movie has varying resolutions, we need to pre-encode
       # This is because ffmpeg can't reliably handle inputs that contain frames with differing resolutions particularly for trimming with `filter_complex`
       @movie.check_frame_resolutions if @transcoder_options[:permit_dynamic_resolution_pre_encode]
@@ -69,7 +66,6 @@ module FFMPEG
     end
 
     def run(&)
-      puts "\n\nRlovelett::FFMPEG::Transcoder run\n\n"
       transcode_movie(&)
       if @transcoder_options[:validate]
         validate_output_file(&)
@@ -108,8 +104,6 @@ module FFMPEG
       # Convert the individual videos into a common format
       @movie.unescaped_paths.each_with_index do |path, index|
         audio_map = determine_audio_for_pre_encode(path)
-
-        puts "\n\n pre_encode_if_necessary inter path: #{@movie.interim_paths[index]}\n\n"
 
         command = "#{@movie.ffmpeg_command} -y -i #{Shellwords.escape(path)} -movflags faststart #{pre_encode_options} -r #{output_frame_rate} -filter_complex \"[0:v]scale=#{max_width}:#{max_height}:force_original_aspect_ratio=decrease,pad=#{max_width}:#{max_height}:(ow-iw)/2:(oh-ih)/2:color=black,setsar=1[Scaled]\" -map \"[Scaled]\" #{audio_map} #{@movie.interim_paths[index]}"
         FFMPEG.logger.info("Running pre-encoding...\n#{command}\n")
@@ -169,7 +163,6 @@ module FFMPEG
     end
 
     def transcode_movie
-      puts "\n\nRlovelett::FFMPEG::Transcoder transcode_movie\n\n"
       pre_encode_if_necessary
 
       @command = "#{@movie.ffmpeg_command} -y #{@raw_options} #{Shellwords.escape(@output_file)}"

--- a/lib/ffmpeg/transcoder.rb
+++ b/lib/ffmpeg/transcoder.rb
@@ -26,7 +26,7 @@ module FFMPEG
       # If the movie has varying resolutions, we need to pre-encode
       # This is because ffmpeg can't reliably handle inputs that contain frames with differing resolutions particularly for trimming with `filter_complex`
       puts "1"
-      @movie.has_dynamic_resolution = check_for_dynamic_resolution(@movie.path)
+      @movie.has_dynamic_resolution = check_for_dynamic_resolution(@movie.path) # TODO: move to movie
       puts "2"
       permit_dynamic_resolution_pre_encode = transcoder_options.fetch(:permit_dynamic_resolution_pre_encode) { false }
       puts "3"
@@ -111,7 +111,7 @@ module FFMPEG
     def pre_encode_if_necessary
       return unless @movie.requires_pre_encode
 
-      @movie.did_pre_encode = true
+      @movie.did_pre_encode = true # TODO: Remove as requires_pre_encode should be enough
 
       # Set a minimum frame rate
       output_frame_rate = [@raw_options[:frame_rate] || @movie.frame_rate, 30].max

--- a/lib/ffmpeg/transcoder.rb
+++ b/lib/ffmpeg/transcoder.rb
@@ -108,7 +108,7 @@ module FFMPEG
         puts "pre_encode_options: #{pre_encode_options}"
         puts "max_width: #{max_width}"
         puts "max_height: #{max_height}"
-        command = "#{@movie.ffmpeg_command} -y -i #{Shellwords.escape(path)} -movflags faststart #{pre_encode_options} -r #{output_frame_rate} -filter_complex \"[0:v]scale=#{max_width}:#{max_height}:force_original_aspect_ratio=decrease,pad=#{max_width}:#{max_height}:(ow-iw)/2:(oh-ih)/2:color=black,setsar=1[Scaled]\" -map \"[Scaled]\" #{audio_map} #{@movie.interim_paths[index]}"
+        command = "#{@movie.ffmpeg_command} -y -i #{Shellwords.escape(path)} -movflags faststart #{pre_encode_options} -r #{output_frame_rate} -filter_complex \"[0:v]scale=#{max_width}:#{max_height},scale=#{max_width}:#{max_height}:force_original_aspect_ratio=decrease,pad=#{max_width}:#{max_height}:(ow-iw)/2:(oh-ih)/2:color=black,setsar=1[Scaled]\" -map \"[Scaled]\" #{audio_map} #{@movie.interim_paths[index]}"
         FFMPEG.logger.info("Running pre-encoding...\n#{command}\n")
         output = ""
 

--- a/lib/ffmpeg/transcoder.rb
+++ b/lib/ffmpeg/transcoder.rb
@@ -33,7 +33,8 @@ module FFMPEG
       puts "should check frame resolutions: #{@transcoder_options[:permit_dynamic_resolution_pre_encode]}\n\n"
       # If the movie has varying resolutions, we need to pre-encode
       # This is because ffmpeg can't reliably handle inputs that contain frames with differing resolutions particularly for trimming with `filter_complex`
-      check_frame_resolutions if @transcoder_options[:permit_dynamic_resolution_pre_encode]
+      @movie.check_frame_resolutions if @transcoder_options[:permit_dynamic_resolution_pre_encode]
+
       if requires_pre_encode
         @movie.paths.each do |path|
           # Make the interim path folder if it doesn't exist

--- a/lib/ffmpeg/transcoder.rb
+++ b/lib/ffmpeg/transcoder.rb
@@ -23,7 +23,7 @@ module FFMPEG
       @movie = movie
       @output_file = output_file
 
-      if @movie.paths.size > 1
+      if true
         @movie.paths.each do |path|
           # Make the interim path folder if it doesn't exist
           dirname = "#{File.dirname(path)}/interim"
@@ -99,6 +99,9 @@ module FFMPEG
         audio_map = determine_audio_for_pre_encode(path)
 
         puts "\n\n pre_encode_if_necessary inter path: #{@movie.interim_paths[index]}\n\n"
+        /vidyard/Alchemist/tmp/development/-d5gXhnk2K_sX5LugjmPAQ/input_1b518082f50620233ee828.mkv
+        /vidyard/Alchemist/tmp/development/-d5gXhnk2K_sX5LugjmPAQ/input_1b518082f50620233ee828.mkv
+        ffmpeg -hide_banner -analyzeduration 15000000 -probesize 15000000 -y -i bad.mkv -movflags faststart -vcodec libx264 -acodec aac -ar 48000 -threads 0 -s 1262x720 -b:a 64k -ac 1 -r 30 -g 60 -b:v 1000k  -aspect 1.7527777777777778 -r 30 -filter_complex "[0:v]scale=1920:1080:force_original_aspect_ratio=decrease,pad=1920:1080:(ow-iw)/2:(oh-ih)/2:color=black,setsar=1[Scaled]" -map "[Scaled]" -map "0:a" ["bad.mkv"]
 
         command = "#{@movie.ffmpeg_command} -y -i #{Shellwords.escape(path)} -movflags faststart #{pre_encode_options} -r #{output_frame_rate} -filter_complex \"[0:v]scale=#{max_width}:#{max_height}:force_original_aspect_ratio=decrease,pad=#{max_width}:#{max_height}:(ow-iw)/2:(oh-ih)/2:color=black,setsar=1[Scaled]\" -map \"[Scaled]\" #{audio_map} #{@movie.interim_paths[index]}"
         FFMPEG.logger.info("Running pre-encoding...\n#{command}\n")

--- a/lib/ffmpeg/transcoder.rb
+++ b/lib/ffmpeg/transcoder.rb
@@ -105,15 +105,12 @@ module FFMPEG
       @movie.unescaped_paths.each_with_index do |path, index|
         audio_map = determine_audio_for_pre_encode(path)
 
+        # Only re-scale the video if there are multiple inputs. If a single input video contains dynamic resolution it can cause issues with the filter_complex filter
         complex_filter = ""
-        unless @transcoder_options[:permit_dynamic_resolution_pre_encode]
-          puts "Applying filter complex due to not being trim"
+        if @movie.paths.size > 1
           complex_filter = "-filter_complex \"[0:v]scale=#{max_width}:#{max_height}:force_original_aspect_ratio=decrease,pad=#{max_width}:#{max_height}:(ow-iw)/2:(oh-ih)/2:color=black,setsar=1[Scaled]\" -map \"[Scaled]\" #{audio_map}"
         end
 
-        puts "pre_encode_options: #{pre_encode_options}"
-        puts "max_width: #{max_width}"
-        puts "max_height: #{max_height}"
         command = "#{@movie.ffmpeg_command} -y -i #{Shellwords.escape(path)} -movflags faststart #{pre_encode_options} -r #{output_frame_rate} #{complex_filter} #{@movie.interim_paths[index]}"
         FFMPEG.logger.info("Running pre-encoding...\n#{command}\n")
         output = ""

--- a/lib/ffmpeg/transcoder.rb
+++ b/lib/ffmpeg/transcoder.rb
@@ -105,10 +105,16 @@ module FFMPEG
       @movie.unescaped_paths.each_with_index do |path, index|
         audio_map = determine_audio_for_pre_encode(path)
 
+        complex_filter = ""
+        unless @transcoder_options[:permit_dynamic_resolution_pre_encode]
+          puts "Applying filter complex due to not being trim"
+          complex_filter = "-filter_complex \"[0:v]scale=#{max_width}:#{max_height},scale=#{max_width}:#{max_height}:force_original_aspect_ratio=decrease,pad=#{max_width}:#{max_height}:(ow-iw)/2:(oh-ih)/2:color=black,setsar=1[Scaled]\" -map \"[Scaled]\" #{audio_map}"
+        end
+
         puts "pre_encode_options: #{pre_encode_options}"
         puts "max_width: #{max_width}"
         puts "max_height: #{max_height}"
-        command = "#{@movie.ffmpeg_command} -y -i #{Shellwords.escape(path)} -movflags faststart #{pre_encode_options} -r #{output_frame_rate} -filter_complex \"[0:v]scale=#{max_width}:#{max_height},scale=#{max_width}:#{max_height}:force_original_aspect_ratio=decrease,pad=#{max_width}:#{max_height}:(ow-iw)/2:(oh-ih)/2:color=black,setsar=1[Scaled]\" -map \"[Scaled]\" #{audio_map} #{@movie.interim_paths[index]}"
+        command = "#{@movie.ffmpeg_command} -y -i #{Shellwords.escape(path)} -movflags faststart #{pre_encode_options} -r #{output_frame_rate} #{complex_filter} #{@movie.interim_paths[index]}"
         FFMPEG.logger.info("Running pre-encoding...\n#{command}\n")
         output = ""
 

--- a/lib/ffmpeg/transcoder.rb
+++ b/lib/ffmpeg/transcoder.rb
@@ -20,7 +20,7 @@ module FFMPEG
 
     def requires_pre_encode
       # Stitches and trims with dynamic resolution require pre-encoding
-      @movie.requires_pre_encode = @movie.paths.size > 1 || (@movie.has_dynamic_resolution && @transcoder_options[:permit_dynamic_resolution_pre_encode])
+      @movie.requires_pre_encode ||= @movie.paths.size > 1 || (@movie.has_dynamic_resolution && @transcoder_options[:permit_dynamic_resolution_pre_encode])
       return @movie.requires_pre_encode
     end
 

--- a/lib/ffmpeg/transcoder.rb
+++ b/lib/ffmpeg/transcoder.rb
@@ -78,7 +78,8 @@ module FFMPEG
     private
     def pre_encode_if_necessary
       # Don't pre-encode single inputs since it doesn't need any size conversion
-      return if @movie.interim_paths.size <= 1
+      puts "\n\n pre_encode_if_necessary \n\n"
+      # return if @movie.interim_paths.size <= 1
 
       # Set a minimum frame rate
       output_frame_rate = [@raw_options[:frame_rate] || @movie.frame_rate, 30].max

--- a/lib/ffmpeg/transcoder.rb
+++ b/lib/ffmpeg/transcoder.rb
@@ -273,8 +273,15 @@ module FFMPEG
       # Get max width and max height of all inputs from each frame
       max_width, max_height = @movie.check_frame_resolutions
 
+      puts "frame resolution max_width: #{max_width}"
+      puts "frame resolution max_height: #{max_height}"
+
       converted_width = (max_height * FIXED_LOWER_TO_UPPER_RATIO).ceil()
       converted_height = (max_width * FIXED_UPPER_TO_LOWER_RATIO).ceil()
+
+      puts "converted_width: #{converted_width}"
+      puts "converted_height: #{converted_height}"
+
       # Convert to always be a 16:9 ratio
       # If the converted width will not be a decrease in resolution, upscale the width
       if converted_width >= max_width
@@ -283,6 +290,9 @@ module FFMPEG
       else
         max_height = converted_height
       end
+
+      puts "final max_width: #{max_width}"
+      puts "final max_height: #{max_height}"
 
       # Ensure dimensions are even for scaling + padding to not have rounding issues
       # Relating to CRT-1554

--- a/lib/ffmpeg/transcoder.rb
+++ b/lib/ffmpeg/transcoder.rb
@@ -98,6 +98,8 @@ module FFMPEG
       @movie.unescaped_paths.each_with_index do |path, index|
         audio_map = determine_audio_for_pre_encode(path)
 
+        puts "\n\n pre_encode_if_necessary inter path: #{@movie.interim_paths[index]}\n\n"
+
         command = "#{@movie.ffmpeg_command} -y -i #{Shellwords.escape(path)} -movflags faststart #{pre_encode_options} -r #{output_frame_rate} -filter_complex \"[0:v]scale=#{max_width}:#{max_height}:force_original_aspect_ratio=decrease,pad=#{max_width}:#{max_height}:(ow-iw)/2:(oh-ih)/2:color=black,setsar=1[Scaled]\" -map \"[Scaled]\" #{audio_map} #{@movie.interim_paths[index]}"
         FFMPEG.logger.info("Running pre-encoding...\n#{command}\n")
         output = ""

--- a/lib/ffmpeg/transcoder.rb
+++ b/lib/ffmpeg/transcoder.rb
@@ -20,7 +20,7 @@ module FFMPEG
 
     def requires_pre_encode
       # Stitches and trims with dynamic resolution require pre-encoding
-      @movie.requires_pre_encode = @movie.paths.size > 1 || (@transcoder_options[:permit_dynamic_resolution_pre_encode] && @movie.has_dynamic_resolution)
+      @movie.requires_pre_encode = @movie.paths.size > 1 || (@movie.has_dynamic_resolution && @transcoder_options[:permit_dynamic_resolution_pre_encode])
       return @movie.requires_pre_encode
     end
 

--- a/lib/ffmpeg/transcoder.rb
+++ b/lib/ffmpeg/transcoder.rb
@@ -99,9 +99,6 @@ module FFMPEG
         audio_map = determine_audio_for_pre_encode(path)
 
         puts "\n\n pre_encode_if_necessary inter path: #{@movie.interim_paths[index]}\n\n"
-        /vidyard/Alchemist/tmp/development/-d5gXhnk2K_sX5LugjmPAQ/input_1b518082f50620233ee828.mkv
-        /vidyard/Alchemist/tmp/development/-d5gXhnk2K_sX5LugjmPAQ/input_1b518082f50620233ee828.mkv
-        ffmpeg -hide_banner -analyzeduration 15000000 -probesize 15000000 -y -i bad.mkv -movflags faststart -vcodec libx264 -acodec aac -ar 48000 -threads 0 -s 1262x720 -b:a 64k -ac 1 -r 30 -g 60 -b:v 1000k  -aspect 1.7527777777777778 -r 30 -filter_complex "[0:v]scale=1920:1080:force_original_aspect_ratio=decrease,pad=1920:1080:(ow-iw)/2:(oh-ih)/2:color=black,setsar=1[Scaled]" -map "[Scaled]" -map "0:a" ["bad.mkv"]
 
         command = "#{@movie.ffmpeg_command} -y -i #{Shellwords.escape(path)} -movflags faststart #{pre_encode_options} -r #{output_frame_rate} -filter_complex \"[0:v]scale=#{max_width}:#{max_height}:force_original_aspect_ratio=decrease,pad=#{max_width}:#{max_height}:(ow-iw)/2:(oh-ih)/2:color=black,setsar=1[Scaled]\" -map \"[Scaled]\" #{audio_map} #{@movie.interim_paths[index]}"
         FFMPEG.logger.info("Running pre-encoding...\n#{command}\n")

--- a/lib/ffmpeg/transcoder.rb
+++ b/lib/ffmpeg/transcoder.rb
@@ -276,14 +276,8 @@ module FFMPEG
       # Get max width and max height of all inputs from each frame
       max_width, max_height = @movie.check_frame_resolutions
 
-      puts "frame resolution max_width: #{max_width}"
-      puts "frame resolution max_height: #{max_height}"
-
       converted_width = (max_height * FIXED_LOWER_TO_UPPER_RATIO).ceil()
       converted_height = (max_width * FIXED_UPPER_TO_LOWER_RATIO).ceil()
-
-      puts "converted_width: #{converted_width}"
-      puts "converted_height: #{converted_height}"
 
       # Convert to always be a 16:9 ratio
       # If the converted width will not be a decrease in resolution, upscale the width
@@ -293,9 +287,6 @@ module FFMPEG
       else
         max_height = converted_height
       end
-
-      puts "final max_width: #{max_width}"
-      puts "final max_height: #{max_height}"
 
       # Ensure dimensions are even for scaling + padding to not have rounding issues
       # Relating to CRT-1554

--- a/lib/ffmpeg/transcoder.rb
+++ b/lib/ffmpeg/transcoder.rb
@@ -108,7 +108,7 @@ module FFMPEG
         complex_filter = ""
         unless @transcoder_options[:permit_dynamic_resolution_pre_encode]
           puts "Applying filter complex due to not being trim"
-          complex_filter = "-filter_complex \"[0:v]scale=#{max_width}:#{max_height},scale=#{max_width}:#{max_height}:force_original_aspect_ratio=decrease,pad=#{max_width}:#{max_height}:(ow-iw)/2:(oh-ih)/2:color=black,setsar=1[Scaled]\" -map \"[Scaled]\" #{audio_map}"
+          complex_filter = "-filter_complex \"[0:v]scale=#{max_width}:#{max_height}:force_original_aspect_ratio=decrease,pad=#{max_width}:#{max_height}:(ow-iw)/2:(oh-ih)/2:color=black,setsar=1[Scaled]\" -map \"[Scaled]\" #{audio_map}"
         end
 
         puts "pre_encode_options: #{pre_encode_options}"

--- a/lib/ffmpeg/transcoder.rb
+++ b/lib/ffmpeg/transcoder.rb
@@ -27,12 +27,7 @@ module FFMPEG
       puts "\n\nRlovelett::FFMPEG::Transcoder initialize\n\n"
       @movie = movie
       @output_file = output_file
-
       @transcoder_options = transcoder_options
-      @transcoder_prefix_options = transcoder_prefix_options
-      @errors = []
-
-      apply_transcoder_options
 
       # If the movie has varying resolutions, we need to pre-encode
       # This is because ffmpeg can't reliably handle inputs that contain frames with differing resolutions particularly for trimming with `filter_complex`
@@ -63,6 +58,11 @@ module FFMPEG
       else
         raise ArgumentError, "Unknown options format '#{options.class}', should be either EncodingOptions, Hash or String."
       end
+
+      @transcoder_prefix_options = transcoder_prefix_options
+      @errors = []
+
+      apply_transcoder_options
     end
 
     def run(&)
@@ -218,9 +218,6 @@ module FFMPEG
     def apply_transcoder_options
        # if true runs #validate_output_file
       @transcoder_options[:validate] = @transcoder_options.fetch(:validate) { true }
-
-      # if true checks for varying resolutions and pre-encodes if necessary
-      @transcoder_options[:permit_dynamic_resolution_pre_encode] = @transcoder_options.fetch(:permit_dynamic_resolution_pre_encode) { false }
 
       return if @movie.calculated_aspect_ratio.nil?
       case @transcoder_options[:preserve_aspect_ratio].to_s

--- a/lib/ffmpeg/transcoder.rb
+++ b/lib/ffmpeg/transcoder.rb
@@ -19,6 +19,7 @@ module FFMPEG
     end
 
     def initialize(movie, output_file, options = EncodingOptions.new, transcoder_options = {}, transcoder_prefix_options = {})
+      puts "\n\nRlovelett::FFMPEG::Transcoder initialize\n\n"
       @movie = movie
       @output_file = output_file
 
@@ -56,6 +57,7 @@ module FFMPEG
     end
 
     def run(&)
+      puts "\n\nRlovelett::FFMPEG::Transcoder run\n\n"
       transcode_movie(&)
       if @transcoder_options[:validate]
         validate_output_file(&)
@@ -154,6 +156,7 @@ module FFMPEG
     end
 
     def transcode_movie
+      puts "\n\nRlovelett::FFMPEG::Transcoder transcode_movie\n\n"
       pre_encode_if_necessary
 
       @command = "#{@movie.ffmpeg_command} -y #{@raw_options} #{Shellwords.escape(@output_file)}"

--- a/lib/ffmpeg/transcoder.rb
+++ b/lib/ffmpeg/transcoder.rb
@@ -19,7 +19,7 @@ module FFMPEG
     end
 
     def requires_pre_encode
-      # Don't pre-encode single inputs since if pre_encode is false as they don't need any size conversion
+      # Stitches and trims with dynamic resolution require pre-encoding
       @movie.requires_pre_encode = @movie.paths.size > 1 || (@transcoder_options[:permit_dynamic_resolution_pre_encode] && @movie.has_dynamic_resolution)
       return @movie.requires_pre_encode
     end
@@ -29,7 +29,7 @@ module FFMPEG
       @output_file = output_file
       @transcoder_options = transcoder_options
 
-      # If the movie has varying resolutions, we need to pre-encode
+      # If the movie has frames with varying resolutions, we need to pre-encode the movie for trims
       # This is because ffmpeg can't reliably handle inputs that contain frames with differing resolutions particularly for trimming with `filter_complex`
       @movie.check_frame_resolutions if @transcoder_options[:permit_dynamic_resolution_pre_encode]
 
@@ -267,6 +267,7 @@ module FFMPEG
     end
 
     def calculate_interim_max_dimensions
+      # Get max width and max height of all inputs from each frame
       max_width, max_height = @movie.check_frame_resolutions
 
       converted_width = (max_height * FIXED_LOWER_TO_UPPER_RATIO).ceil()

--- a/lib/ffmpeg/transcoder.rb
+++ b/lib/ffmpeg/transcoder.rb
@@ -273,7 +273,7 @@ module FFMPEG
     end
 
     def calculate_interim_max_dimensions
-      max_width, max_height = check_frame_resolutions
+      max_width, max_height = @movie.check_frame_resolutions
 
       converted_width = (max_height * FIXED_LOWER_TO_UPPER_RATIO).ceil()
       converted_height = (max_width * FIXED_UPPER_TO_LOWER_RATIO).ceil()

--- a/lib/ffmpeg/transcoder.rb
+++ b/lib/ffmpeg/transcoder.rb
@@ -25,11 +25,15 @@ module FFMPEG
 
       # If the movie has varying resolutions, we need to pre-encode
       # This is because ffmpeg can't reliably handle inputs that contain frames with differing resolutions particularly for trimming with `filter_complex`
+      puts "1"
       @movie.has_dynamic_resolution = check_for_dynamic_resolution(@movie.path)
+      puts "2"
       permit_dynamic_resolution_pre_encode = transcoder_options.fetch(:permit_dynamic_resolution_pre_encode) { false }
+      puts "3"
 
       # Don't pre-encode single inputs since if pre_encode is false as they don't need any size conversion
       @movie.requires_pre_encode = @movie.paths.size > 1 || (permit_dynamic_resolution_pre_encode && @movie.has_dynamic_resolution)
+      puts "4"
 
       if @movie.requires_pre_encode
         @movie.paths.each do |path|

--- a/lib/ffmpeg/transcoder.rb
+++ b/lib/ffmpeg/transcoder.rb
@@ -273,7 +273,7 @@ module FFMPEG
     end
 
     def calculate_interim_max_dimensions
-      max_width, max_height = frame_based_resolution
+      max_width, max_height = check_frame_resolutions
 
       converted_width = (max_height * FIXED_LOWER_TO_UPPER_RATIO).ceil()
       converted_height = (max_width * FIXED_UPPER_TO_LOWER_RATIO).ceil()

--- a/lib/ffmpeg/transcoder.rb
+++ b/lib/ffmpeg/transcoder.rb
@@ -105,6 +105,9 @@ module FFMPEG
       @movie.unescaped_paths.each_with_index do |path, index|
         audio_map = determine_audio_for_pre_encode(path)
 
+        puts "pre_encode_options: #{pre_encode_options}"
+        puts "max_width: #{max_width}"
+        puts "max_height: #{max_height}"
         command = "#{@movie.ffmpeg_command} -y -i #{Shellwords.escape(path)} -movflags faststart #{pre_encode_options} -r #{output_frame_rate} -filter_complex \"[0:v]scale=#{max_width}:#{max_height}:force_original_aspect_ratio=decrease,pad=#{max_width}:#{max_height}:(ow-iw)/2:(oh-ih)/2:color=black,setsar=1[Scaled]\" -map \"[Scaled]\" #{audio_map} #{@movie.interim_paths[index]}"
         FFMPEG.logger.info("Running pre-encoding...\n#{command}\n")
         output = ""

--- a/spec/ffmpeg/transcoder_spec.rb
+++ b/spec/ffmpeg/transcoder_spec.rb
@@ -345,13 +345,7 @@ module FFMPEG
       describe 'creates interim inputs with scaling correctly applied based on input files' do
         it 'with audio' do
           transcoder = Transcoder.new(movie_with_multiple_dimension_inputs, output_path, EncodingOptions.new)
-          allow(Open3).to receive(:popen3) do |*args|
-            # Log the arguments passed to popen3
-            puts "Open3.popen3 called with: #{args.join(' ')}\n"
 
-            # Continue with the original behavior
-            # Open3.popen3(*args)
-          end
           expect(Open3).to receive(:popen3).exactly(2).times # prevent ffprobe calls from being evaluated (check_frame_resolutions)
           expect(Open3).to receive(:popen3).twice.with match(/.*\[0\:v\]scale\=854\:480.*pad\=854\:480\:\(ow\-iw\)\/2\:\(oh\-ih\)\/2\:color\=black.*\-map \"0\:a\".*/)
 

--- a/spec/ffmpeg/transcoder_spec.rb
+++ b/spec/ffmpeg/transcoder_spec.rb
@@ -345,7 +345,13 @@ module FFMPEG
       describe 'creates interim inputs with scaling correctly applied based on input files' do
         it 'with audio' do
           transcoder = Transcoder.new(movie_with_multiple_dimension_inputs, output_path, EncodingOptions.new)
+          allow(Open3).to receive(:popen3) do |*args|
+            # Log the arguments passed to popen3
+            puts "Open3.popen3 called with: #{args.join(' ')}\n"
 
+            # Continue with the original behavior
+            # Open3.popen3(*args)
+          end
           expect(Open3).to receive(:popen3).exactly(2).times # prevent ffprobe calls from being evaluated (check_frame_resolutions)
           expect(Open3).to receive(:popen3).twice.with match(/.*\[0\:v\]scale\=854\:480.*pad\=854\:480\:\(ow\-iw\)\/2\:\(oh\-ih\)\/2\:color\=black.*\-map \"0\:a\".*/)
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,9 +8,6 @@ FFMPEG.logger = Logger.new(nil)
 RSpec.configure do |config|
   config.filter_run focus: true
   config.run_all_when_everything_filtered = true
-  config.expect_with :rspec do |c|
-    c.max_formatted_output_length = nil
-  end
 end
 
 def fixture_path

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,9 @@ FFMPEG.logger = Logger.new(nil)
 RSpec.configure do |config|
   config.filter_run focus: true
   config.run_all_when_everything_filtered = true
+  config.expect_with :rspec do |c|
+    c.max_formatted_output_length = nil
+  end
 end
 
 def fixture_path


### PR DESCRIPTION
![](https://gifdb.com/images/high/network-dynamic-installations-gkxexxrw8wls9zpb.gif)

Following investigations into CRT-1953, trims have problems with Audio / Video sync or duration checks when they contain frames with differing resolutions.
These particular videos have a resolution in the metadata, but individual frames can have different resolutions which is namely a problem with `filter_complex`

Pre-encoding alike how we do for stitches seems to resolve this issue. 
Note this does increase processing time for these particular videos. `permit_dynamic_resolution_pre_encode` is available to allow alchemist to allow this to only happen for trims and not all videos as normal encodes are not affected.

Also modifies stitching to do frame resolution checks to ensure we have the highest resolution amongst the frames incase the metadata is incorrect.

Paired with https://github.com/Vidyard/Alchemist/pull/1240