### PR TITLE
[CRT-2085] Ensure Rotation Is Assigned If Any side_data_list Entry Contains It, Bump CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Repo Owners
-*  @Kyrluckechuck @Vidyard/create-platform
+*  @Kyrluckechuck @Vidyard/tech-stream

--- a/lib/ffmpeg/movie.rb
+++ b/lib/ffmpeg/movie.rb
@@ -103,13 +103,10 @@ module FFMPEG
 
           @video_stream = "#{video_stream[:codec_name]} (#{video_stream[:profile]}) (#{video_stream[:codec_tag_string]} / #{video_stream[:codec_tag]}), #{colorspace}, #{resolution} [SAR #{sar} DAR #{dar}]"
 
+          @rotation = nil
+
           video_stream[:side_data_list].each do |side_data_entry|
-            @rotation = if side_data_entry.key?(:rotation)
-                          side_data_entry[:rotation].to_i
-                        else
-                          nil
-                        end
-            break unless @rotation.nil?
+            @rotation = side_data_entry[:rotation].to_i if side_data_entry.key?(:rotation)
           end if video_stream.key?(:side_data_list)
         end
 

--- a/lib/ffmpeg/movie.rb
+++ b/lib/ffmpeg/movie.rb
@@ -109,6 +109,7 @@ module FFMPEG
                         else
                           nil
                         end
+            break if @rotation
           end if video_stream.key?(:side_data_list)
         end
 

--- a/lib/ffmpeg/movie.rb
+++ b/lib/ffmpeg/movie.rb
@@ -109,7 +109,7 @@ module FFMPEG
                         else
                           nil
                         end
-            break if @rotation.present?
+            break unless @rotation.nil?
           end if video_stream.key?(:side_data_list)
         end
 

--- a/lib/ffmpeg/movie.rb
+++ b/lib/ffmpeg/movie.rb
@@ -109,7 +109,7 @@ module FFMPEG
                         else
                           nil
                         end
-            break if @rotation
+            break if @rotation.present?
           end if video_stream.key?(:side_data_list)
         end
 


### PR DESCRIPTION
![](https://media1.giphy.com/media/VnNIVrtolsL00Um6xd/giphy.gif)

## Description
There is currently a bug where the rotation will not be correctly detected from the `side_data_list` if there are multiple entries and the last one is not the one to contain the rotation entry.

This updates it to only overwrite the rotation if another rotation is detected (this will keep it the "same" as before)

Example data that this will fix:
```
            "side_data_list": [
                {
                    "side_data_type": "DOVI configuration record",
                    "dv_version_major": 1,
                    "dv_version_minor": 0,
                    "dv_profile": 8,
                    "dv_level": 4,
                    "rpu_present_flag": 1,
                    "el_present_flag": 0,
                    "bl_present_flag": 1,
                    "dv_bl_signal_compatibility_id": 4
                },
                {
                    "side_data_type": "Display Matrix",
                    "displaymatrix": "\n00000000:            0       65536           0\n00000001:       -65536           0           0\n00000002:     70778880           0  1073741824\n",
                    "rotation": -90
                },
                {
                    "side_data_type": "Ambient viewing environment",
                    "ambient_illuminance": "3140000/10000",
                    "ambient_light_x": "15635/50000",
                    "ambient_light_y": "16450/50000"
                }
            ]
```