### PR TITLE
[NOVA-2185] Support HTTP for interim files

### DIFF
--- a/lib/ffmpeg/transcoder.rb
+++ b/lib/ffmpeg/transcoder.rb
@@ -26,6 +26,7 @@ module FFMPEG
     end
 
     def initialize(movie, output_file, options = EncodingOptions.new, transcoder_options = {}, transcoder_prefix_options = {})
+      puts "|| rlovelett || initialize || #{movie.paths.inspect}"
       @movie = movie
       @output_file = output_file
       @transcoder_options = transcoder_options
@@ -40,7 +41,9 @@ module FFMPEG
 
           if path.start_with?("http")
             dirname = "#{TEMP_DIR}/interim/#{SecureRandom.urlsafe_base64}/"
+            puts "|| rlovelett using random interim directory for HTTP URL #{dirname}"
           else
+            puts "|| rlovelett using local directory for local file #{dirname}"
             dirname = "#{TEMP_DIR}/interim#{File.dirname(path)}/"
           end
           unless File.directory?(dirname)
@@ -48,6 +51,7 @@ module FFMPEG
           end
           # Example output: /tmp/rlovelett/interim/test_gv6Hw86ryqklKNiYCu9a8w.mp4
           interim_path = "#{dirname}#{File.basename(path, File.extname(path))}_#{SecureRandom.urlsafe_base64}.mp4"
+          puts "|| rlovelett interim path #{interim_path}"
           @movie.interim_paths << interim_path
         end
       else

--- a/lib/ffmpeg/transcoder.rb
+++ b/lib/ffmpeg/transcoder.rb
@@ -26,7 +26,6 @@ module FFMPEG
     end
 
     def initialize(movie, output_file, options = EncodingOptions.new, transcoder_options = {}, transcoder_prefix_options = {})
-      puts "|| rlovelett || initialize || #{movie.paths.inspect}"
       @movie = movie
       @output_file = output_file
       @transcoder_options = transcoder_options
@@ -38,12 +37,9 @@ module FFMPEG
       if requires_pre_encode
         @movie.paths.each do |path|
           # Make the interim path folder if it doesn't exist
-
           if path.start_with?("http")
             dirname = "#{TEMP_DIR}/interim/#{SecureRandom.urlsafe_base64}/"
-            puts "|| rlovelett using random interim directory for HTTP URL #{dirname}"
           else
-            puts "|| rlovelett using local directory for local file #{dirname}"
             dirname = "#{TEMP_DIR}/interim#{File.dirname(path)}/"
           end
           unless File.directory?(dirname)

--- a/lib/ffmpeg/transcoder.rb
+++ b/lib/ffmpeg/transcoder.rb
@@ -2,7 +2,6 @@ require 'open3'
 require 'shellwords'
 require 'fileutils'
 require 'securerandom'
-require 'digest'
 
 FIXED_LOWER_TO_UPPER_RATIO = 16.0/9.0
 FIXED_UPPER_TO_LOWER_RATIO = 9.0/16.0

--- a/lib/ffmpeg/transcoder.rb
+++ b/lib/ffmpeg/transcoder.rb
@@ -2,6 +2,7 @@ require 'open3'
 require 'shellwords'
 require 'fileutils'
 require 'securerandom'
+require 'digest'
 
 FIXED_LOWER_TO_UPPER_RATIO = 16.0/9.0
 FIXED_UPPER_TO_LOWER_RATIO = 9.0/16.0
@@ -38,7 +39,11 @@ module FFMPEG
         @movie.paths.each do |path|
           # Make the interim path folder if it doesn't exist
 
-          dirname = "#{TEMP_DIR}/interim#{File.dirname(path)}/"
+          if path.start_with?("http")
+            dirname = "#{TEMP_DIR}/interim/#{SecureRandom.urlsafe_base64}/"
+          else
+            dirname = "#{TEMP_DIR}/interim#{File.dirname(path)}/"
+          end
           unless File.directory?(dirname)
             FileUtils.mkdir_p(dirname)
           end

--- a/lib/ffmpeg/transcoder.rb
+++ b/lib/ffmpeg/transcoder.rb
@@ -47,7 +47,6 @@ module FFMPEG
           end
           # Example output: /tmp/rlovelett/interim/test_gv6Hw86ryqklKNiYCu9a8w.mp4
           interim_path = "#{dirname}#{File.basename(path, File.extname(path))}_#{SecureRandom.urlsafe_base64}.mp4"
-          puts "|| rlovelett interim path #{interim_path}"
           @movie.interim_paths << interim_path
         end
       else


### PR DESCRIPTION
HTTP input URLs were failing when it tried to create the interim directories.
Now it uses a random uuid if it is a http url.

https://vidyard.atlassian.net/browse/NOVA-2185